### PR TITLE
ci: enable clippy and cargo check

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,15 +134,16 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705229514,
-        "narHash": "sha256-itILy0zimR/iyUGq5Dgg0fiW8plRDyxF153LWGsg3Cw=",
-        "owner": "cachix",
+        "lastModified": 1707593974,
+        "narHash": "sha256-AGBTwjp4IiJNCIgUIp/H+yLeT7Oqli7X/HBz0LtW4dw=",
+        "owner": "mrcjkb",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ffa9a5b90b0acfaa03b1533b83eaf5dead819a05",
+        "rev": "bfc996601d0ca70fde408f742cf290800ff8c2c2",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
+        "owner": "mrcjkb",
+        "ref": "clippy",
         "repo": "pre-commit-hooks.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,9 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     pre-commit-hooks = {
-      url = "github:cachix/pre-commit-hooks.nix";
+      # TODO: https://github.com/cachix/pre-commit-hooks.nix/pull/396
+      # url = "github:cachix/pre-commit-hooks.nix";
+      url = "github:mrcjkb/pre-commit-hooks.nix/clippy";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -44,8 +46,18 @@
           hooks = {
             alejandra.enable = true;
             rustfmt.enable = true;
-            # clippy.enable = true;
-            # cargo-check.enable = true;
+            clippy.enable = true;
+            cargo-check.enable = true;
+          };
+          settings = {
+            runtimeDeps = pkgs.rocks.buildInputs ++ pkgs.rocks.nativeBuildInputs;
+            rust.cargoDeps = pkgs.rustPlatform.importCargoLock {
+              lockFile = ./Cargo.lock;
+            };
+            clippy = {
+              denyWarnings = true;
+              allFeatures = true;
+            };
           };
         };
       in {

--- a/rocks-bin/src/search.rs
+++ b/rocks-bin/src/search.rs
@@ -43,7 +43,7 @@ pub async fn search(data: Search, config: &Config) -> Result<()> {
 
             if data.porcelain {
                 versions.for_each(|version| {
-                    println!("{} {} {} {}", key, version, "src|rockspec", config.server)
+                    println!("{} {} src|rockspec {}", key, version, config.server)
                 });
             } else {
                 let mut tree = StringTreeNode::new(key.to_owned());

--- a/rocks-lib/src/manifest/pull_manifest.rs
+++ b/rocks-lib/src/manifest/pull_manifest.rs
@@ -104,9 +104,11 @@ mod tests {
         let server = start_test_server("manifest-5.1".into());
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
-        let mut config = Config::default();
 
-        config.lua_version = Some("5.1".into());
+        let config = Config {
+            lua_version: Some("5.1".into()),
+            ..Config::default()
+        };
 
         manifest_from_server(url_str, &config).await.unwrap();
     }

--- a/rocks-lib/src/rockspec/build/mod.rs
+++ b/rocks-lib/src/rockspec/build/mod.rs
@@ -388,14 +388,13 @@ mod tests {
 
     #[tokio::test]
     pub async fn deserialize_build_type() {
-        let build_type: BuildType = serde_json::from_str("\"builtin\"".into()).unwrap();
+        let build_type: BuildType = serde_json::from_str("\"builtin\"").unwrap();
         assert_eq!(build_type, BuildType::Builtin);
-        let build_type: BuildType = serde_json::from_str("\"module\"".into()).unwrap();
+        let build_type: BuildType = serde_json::from_str("\"module\"").unwrap();
         assert_eq!(build_type, BuildType::Builtin);
-        let build_type: BuildType = serde_json::from_str("\"make\"".into()).unwrap();
+        let build_type: BuildType = serde_json::from_str("\"make\"").unwrap();
         assert_eq!(build_type, BuildType::Make);
-        let build_type: BuildType =
-            serde_json::from_str("\"luarocks_build_rust_mlua\"".into()).unwrap();
+        let build_type: BuildType = serde_json::from_str("\"luarocks_build_rust_mlua\"").unwrap();
         assert_eq!(
             build_type,
             BuildType::LuaRock("luarocks_build_rust_mlua".into())

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -592,7 +592,7 @@ mod tests {
             per_platform
                 .get(&PlatformIdentifier::Windows)
                 .unwrap()
-                .into_iter()
+                .iter()
                 .filter(|dep| dep.matches(&neorg_override)
                     || dep.matches(&toml_edit)
                     || dep.matches(&toml))
@@ -603,7 +603,7 @@ mod tests {
             per_platform
                 .get(&PlatformIdentifier::Unix)
                 .unwrap()
-                .into_iter()
+                .iter()
                 .filter(|dep| dep.matches(&neorg_override)
                     || dep.matches(&toml_edit)
                     || dep.matches(&toml))
@@ -614,7 +614,7 @@ mod tests {
             per_platform
                 .get(&PlatformIdentifier::Linux)
                 .unwrap()
-                .into_iter()
+                .iter()
                 .filter(|dep| dep.matches(&neorg_override)
                     || dep.matches(&toml_edit)
                     || dep.matches(&toml))


### PR DESCRIPTION
Stacked on #14.

This enables clippy and cargo check in CI.
For now, I've switched to my fork of pre-commit-hooks.nix, pending: https://github.com/cachix/pre-commit-hooks.nix/pull/396.