### PR TITLE
[FEATURE]: Add `write-rockspec` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,9 +1916,11 @@ dependencies = [
  "octocrab",
  "rocks-lib",
  "rustyline",
+ "spinners",
  "termcolor",
  "text_trees",
  "tokio",
+ "users",
 ]
 
 [[package]]
@@ -2324,6 +2332,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spinners"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "strum 0.24.1",
+]
+
+[[package]]
 name = "ssri"
 version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2370,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
 
 [[package]]
 name = "strum"
@@ -2776,6 +2798,16 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +98,23 @@ checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -231,6 +263,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,7 +316,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -279,6 +324,42 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "clipboard-win"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec832972fefb8cf9313b45a0d1945e29c9c251f1d4c6eafc5fe2124c02d2e81"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -425,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +525,12 @@ checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -465,6 +558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +578,17 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "flate2"
@@ -576,7 +686,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -626,8 +736,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -635,6 +747,35 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "git-url-parse"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b037f7449dd4a8b711e660301ff1ff28aa00eea09698421fb2d78db51a7b7a72"
+dependencies = [
+ "color-eyre",
+ "regex",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "h2"
@@ -647,7 +788,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap",
  "slab",
  "tokio",
@@ -689,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,13 +859,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -742,8 +926,8 @@ dependencies = [
  "crossbeam-channel",
  "form_urlencoded",
  "futures",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "log",
  "once_cell",
  "regex",
@@ -764,8 +948,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -778,16 +962,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.0.0",
+ "hyper 1.1.0",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.1.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -832,6 +1109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "iri-string"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +1152,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1177,20 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -891,6 +1207,32 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -941,7 +1283,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1016,6 +1358,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nucleo"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,10 +1399,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1072,6 +1454,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "octocrab"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b04754b007c5d3a027f77776d13619d8baab2fd73ab03608ca08ae65b8c7c1"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,7 +1521,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1135,6 +1556,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -1183,10 +1610,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1260,6 +1717,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1388,9 +1855,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1400,7 +1867,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1417,14 +1884,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rocks"
 version = "0.1.0"
 dependencies = [
  "clap",
  "eyre",
+ "git-url-parse",
+ "git2",
  "itertools",
  "nucleo",
+ "octocrab",
  "rocks-lib",
+ "rustyline",
+ "termcolor",
  "text_trees",
  "tokio",
 ]
@@ -1448,8 +1934,8 @@ dependencies = [
  "serde_json",
  "serial_test",
  "ssri",
- "strum",
- "strum_macros",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
  "tokio",
  "zip",
 ]
@@ -1480,12 +1966,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1504,6 +2044,28 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rustyline"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
 ]
 
 [[package]]
@@ -1526,6 +2088,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -1583,7 +2154,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1594,6 +2165,16 @@ checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -1631,7 +2212,7 @@ checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1668,6 +2249,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +2285,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
+name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "backtrace",
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +2316,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "ssri"
@@ -1717,9 +2348,28 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "strum_macros"
@@ -1731,7 +2381,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1739,6 +2389,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1792,6 +2453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "text_trees"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,7 +2484,17 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1824,10 +2504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1835,6 +2517,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -1876,7 +2568,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1886,6 +2578,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1904,6 +2607,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da193277a4e2c33e59e09b5861580c33dd0a637c3883d0fa74ba40c0374af2e"
+dependencies = [
+ "bitflags 2.4.2",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,8 +2661,21 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1926,6 +2685,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1980,6 +2761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2775,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2001,6 +2789,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -2059,7 +2853,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2093,7 +2887,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2112,6 +2906,46 @@ checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2261,6 +3095,12 @@ name = "xxhash-rust"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,7 @@ dependencies = [
  "octocrab",
  "rocks-lib",
  "rustyline",
+ "spdx",
  "spinners",
  "termcolor",
  "text_trees",
@@ -2323,6 +2324,15 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spdx"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bde1398b09b9f93fc2fc9b9da86e362693e999d3a54a8ac47a99a5a73f638b"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/rocks-bin/Cargo.toml
+++ b/rocks-bin/Cargo.toml
@@ -13,6 +13,8 @@ nucleo = "0.3.0"
 octocrab = "0.34.0"
 rocks-lib = { path = "../rocks-lib/" }
 rustyline = "13.0.0"
+spinners = "4.1.1"
 termcolor = "1.4.1"
 text_trees = "0.1.2"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
+users = "0.11.0"

--- a/rocks-bin/Cargo.toml
+++ b/rocks-bin/Cargo.toml
@@ -13,6 +13,7 @@ nucleo = "0.3.0"
 octocrab = "0.34.0"
 rocks-lib = { path = "../rocks-lib/" }
 rustyline = "13.0.0"
+spdx = "0.10.3"
 spinners = "4.1.1"
 termcolor = "1.4.1"
 text_trees = "0.1.2"

--- a/rocks-bin/Cargo.toml
+++ b/rocks-bin/Cargo.toml
@@ -6,8 +6,13 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.17", features = ["derive"] }
 eyre = "0.6.11"
+git-url-parse = "0.4.4"
+git2 = "0.18.2"
 itertools = "0.12.0"
 nucleo = "0.3.0"
+octocrab = "0.34.0"
 rocks-lib = { path = "../rocks-lib/" }
+rustyline = "13.0.0"
+termcolor = "1.4.1"
 text_trees = "0.1.2"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -4,9 +4,9 @@ use clap::{Parser, Subcommand};
 use rocks_lib::config::Config;
 
 mod download;
+mod rockspec;
 mod search;
 mod unpack;
-mod rockspec;
 
 /// An small and efficient Lua package manager.
 #[derive(Parser)]
@@ -160,7 +160,9 @@ async fn main() {
             Commands::UnpackRemote(unpack_data) => {
                 unpack::unpack_remote(unpack_data, &config).await.unwrap()
             }
-            Commands::WriteRockspec(rockspec_data) => rockspec::write_rockspec(rockspec_data).await.unwrap(),
+            Commands::WriteRockspec(rockspec_data) => {
+                rockspec::write_rockspec(rockspec_data).await.unwrap()
+            }
             _ => unimplemented!(),
         },
         None => {

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -6,6 +6,7 @@ use rocks_lib::config::Config;
 mod download;
 mod search;
 mod unpack;
+mod rockspec;
 
 /// An small and efficient Lua package manager.
 #[derive(Parser)]
@@ -123,7 +124,7 @@ enum Commands {
     /// Tell which file corresponds to a given module name.
     Which,
     /// Write a template for a rockspec file.
-    WriteRockspec,
+    WriteRockspec(rockspec::WriteRockspec),
 }
 
 #[tokio::main]
@@ -159,6 +160,7 @@ async fn main() {
             Commands::UnpackRemote(unpack_data) => {
                 unpack::unpack_remote(unpack_data, &config).await.unwrap()
             }
+            Commands::WriteRockspec(rockspec_data) => rockspec::write_rockspec(rockspec_data).await.unwrap(),
             _ => unimplemented!(),
         },
         None => {

--- a/rocks-bin/src/rockspec/github_metadata.rs
+++ b/rocks-bin/src/rockspec/github_metadata.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 #[derive(Debug)]
 pub struct RepoMetadata {
     pub name: String,
+    pub description: Option<String>,
     pub license: Option<String>,
     pub labels: Option<Vec<String>>,
     pub contributors: Vec<String>,
@@ -36,6 +37,7 @@ pub async fn get_metadata_for(directory: Option<&PathBuf>) -> Result<Option<Repo
 
         Ok(Some(RepoMetadata {
             name: repo_data.name,
+            description: repo_data.description,
             license: repo_data.license.map(|license| license.name),
             labels: repo_data.topics,
             contributors: contributors

--- a/rocks-bin/src/rockspec/github_metadata.rs
+++ b/rocks-bin/src/rockspec/github_metadata.rs
@@ -1,0 +1,52 @@
+use eyre::eyre;
+use eyre::Result;
+use git2::Repository;
+///! Retrieves metadata from a given github repository
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct RepoMetadata {
+    pub name: String,
+    pub license: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub contributors: Vec<String>,
+}
+
+/// Retrieves metadata for a given directory
+pub async fn get_metadata_for(directory: Option<&PathBuf>) -> Result<Option<RepoMetadata>> {
+    let repo = match directory {
+        Some(path) => Repository::discover(path)?,
+        None => Repository::open_from_env()?,
+    };
+
+    // NOTE(vhyrro): Temporary value is required. Thank the borrow checker.
+    let ret = if let Some(remote) = repo.find_remote("origin")?.url() {
+        let parsed_url = git_url_parse::GitUrl::parse(remote)?;
+
+        let (owner, name) = match (parsed_url.owner, parsed_url.name) {
+            (Some(owner), name) => (owner, name),
+            _ => return Err(eyre!("unable to parse remote `origin` - it's likely that your upstream remote is malformed!")),
+        };
+
+        let octocrab = octocrab::instance();
+        let repo_handler = octocrab.repos(owner, name);
+
+        let contributors = repo_handler.list_contributors().send().await?;
+        let repo_data = repo_handler.get().await?;
+
+        Ok(Some(RepoMetadata {
+            name: repo_data.name,
+            license: repo_data.license.map(|license| license.name),
+            labels: repo_data.topics,
+            contributors: contributors
+                .items
+                .into_iter()
+                .map(|contributor| contributor.author.login)
+                .collect(),
+        }))
+    } else {
+        Ok(None)
+    };
+
+    ret
+}

--- a/rocks-bin/src/rockspec/github_metadata.rs
+++ b/rocks-bin/src/rockspec/github_metadata.rs
@@ -1,4 +1,3 @@
-///! Retrieves metadata from a given github repository
 use eyre::eyre;
 use eyre::Result;
 use git2::Repository;

--- a/rocks-bin/src/rockspec/github_metadata.rs
+++ b/rocks-bin/src/rockspec/github_metadata.rs
@@ -1,5 +1,4 @@
 ///! Retrieves metadata from a given github repository
-
 use eyre::eyre;
 use eyre::Result;
 use git2::Repository;

--- a/rocks-bin/src/rockspec/github_metadata.rs
+++ b/rocks-bin/src/rockspec/github_metadata.rs
@@ -1,7 +1,8 @@
+///! Retrieves metadata from a given github repository
+
 use eyre::eyre;
 use eyre::Result;
 use git2::Repository;
-///! Retrieves metadata from a given github repository
 use std::path::PathBuf;
 
 #[derive(Debug)]

--- a/rocks-bin/src/rockspec/mod.rs
+++ b/rocks-bin/src/rockspec/mod.rs
@@ -1,0 +1,4 @@
+mod write_rockspec;
+mod github_metadata;
+
+pub use write_rockspec::*;

--- a/rocks-bin/src/rockspec/mod.rs
+++ b/rocks-bin/src/rockspec/mod.rs
@@ -1,4 +1,4 @@
-mod write_rockspec;
 mod github_metadata;
+mod write_rockspec;
 
 pub use write_rockspec::*;

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -1,11 +1,6 @@
-use std::{collections::HashMap, io::Write};
-
 use clap::Args;
 use eyre::Result;
 use spinners::{Spinner, Spinners};
-use termcolor::{
-    Buffer, BufferedStandardStream, Color, ColorChoice, ColorSpec, StandardStream, WriteColor,
-};
 
 use crate::rockspec::github_metadata::{self, RepoMetadata};
 
@@ -27,7 +22,7 @@ macro_rules! empty_or {
 #[derive(Args)]
 pub struct WriteRockspec {}
 
-pub async fn write_rockspec(data: WriteRockspec) -> Result<()> {
+pub async fn write_rockspec(_data: WriteRockspec) -> Result<()> {
     let mut spinner = Spinner::new(Spinners::Dots, "Fetching repository metadata...".into());
 
     let repo_metadata = github_metadata::get_metadata_for(None)

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -38,7 +38,7 @@ pub async fn write_rockspec(data: WriteRockspec) -> Result<()> {
 
     let mut editor = rustyline::Editor::<(), _>::new()?;
 
-    editor.readline(format!("name (empty for '{}'):", repo_metadata.name).as_str())?;
+    editor.readline(format!("name (empty for '{}'): ", repo_metadata.name).as_str())?;
 
     Ok(())
 }

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -55,7 +55,7 @@ pub struct WriteRockspec {
     #[arg(short, long)]
     description: Option<String>,
 
-    /// The license of the rock. Generic license names will try to be inferred.
+    /// The license of the rock. Generic license names will be inferred.
     #[arg(short, long, value_parser = parse_license_wrapper)]
     license: Option<Either<LicenseId, ()>>,
 

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -1,0 +1,15 @@
+use clap::Args;
+use eyre::Result;
+
+use crate::rockspec::github_metadata;
+
+#[derive(Args)]
+pub struct WriteRockspec {
+
+}
+
+pub async fn write_rockspec(data: WriteRockspec) -> Result<()> {
+    let repo_metadata = github_metadata::get_metadata_for(None).await?.unwrap();
+    println!("{:?}", repo_metadata);
+    todo!()
+}

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -38,6 +38,7 @@ pub async fn write_rockspec(data: WriteRockspec) -> Result<()> {
 
     let mut editor = rustyline::Editor::<(), _>::new()?;
 
+    // TODO: Make prompts coloured
     editor.readline(format!("name (empty for '{}'): ", repo_metadata.name).as_str())?;
 
     Ok(())

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -130,16 +130,16 @@ pub async fn write_rockspec(_data: WriteRockspec) -> Result<()> {
             .unwrap_or("*** enter a license ***".into())
     )?;
 
-    let authors = parse!(
+    let maintainer = parse!(
         editor.readline(
             format!(
-                "Authors (empty for '[{}]'): ",
-                repo_metadata.contributors.join(" ")
+                "Maintainer (empty for '{}'): ",
+                repo_metadata.contributors.first().unwrap_or(&"".into())
             )
             .as_str()
         ),
-        parse_list,
-        repo_metadata.contributors
+        identity,
+        repo_metadata.contributors.first().unwrap_or(&"".into())
     )?;
 
     let labels = parse!(
@@ -169,11 +169,12 @@ package = "{package_name}"
 version = "dev-1"
 
 source = {{
-    url = "*** provide a url here***",
+    url = "*** provide a url here ***",
 }}
 
 description = {{
     summary = "{summary}",
+    maintainer = "{maintainer}",
     license = "{license}",
     labels = {{ {labels} }},
 }}
@@ -185,7 +186,8 @@ build = {{
             package_name = package_name,
             summary = description,
             license = license,
-            labels = labels
+            labels = labels,
+            maintainer = maintainer,
         )
         .trim(),
     )?;

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -1,15 +1,44 @@
+use std::collections::HashMap;
+
 use clap::Args;
 use eyre::Result;
+use spinners::{Spinner, Spinners};
 
-use crate::rockspec::github_metadata;
+use crate::rockspec::github_metadata::{self, RepoMetadata};
+
+// General notes and ideas:
+// - Should we require the user to create a "project" in order to use this command?
+// - Should we grab all collaborators by default? That might end up being massive
+//   if there's a sizeable project.
 
 #[derive(Args)]
-pub struct WriteRockspec {
-
-}
+pub struct WriteRockspec {}
 
 pub async fn write_rockspec(data: WriteRockspec) -> Result<()> {
-    let repo_metadata = github_metadata::get_metadata_for(None).await?.unwrap();
-    println!("{:?}", repo_metadata);
-    todo!()
+    let mut spinner = Spinner::new(Spinners::Dots, "Fetching repository metadata...".into());
+
+    let repo_metadata = github_metadata::get_metadata_for(None)
+        .await?
+        .unwrap_or_else(|| RepoMetadata {
+            name: std::env::current_dir()
+                .expect("unable to get current working directory")
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string(),
+            license: None,
+            contributors: vec![users::get_current_username()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string()],
+            labels: None,
+        });
+
+    spinner.stop();
+
+    let mut editor = rustyline::Editor::<(), _>::new()?;
+
+    editor.readline(format!("name (empty for '{}'):", repo_metadata.name).as_str())?;
+
+    Ok(())
 }

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -77,15 +77,15 @@ pub struct WriteRockspec {
 }
 
 fn parse_license_wrapper(s: &str) -> std::result::Result<Option<LicenseId>, String> {
-    Ok(parse_license(s.to_string()).map_err(|err| err.to_string())?)
+    parse_license(s.to_string()).map_err(|err| err.to_string())
 }
 
 fn parse_version_wrapper(s: &str) -> std::result::Result<LuaDependency, String> {
-    Ok(parse_version(s.to_string()).map_err(|err| err.to_string())?)
+    parse_version(s.to_string()).map_err(|err| err.to_string())
 }
 
 fn parse_list_wrapper(s: &str) -> std::result::Result<Vec<String>, String> {
-    Ok(parse_list(s.to_string()).map_err(|err| err.to_string())?)
+    parse_list(s.to_string()).map_err(|err| err.to_string())
 }
 
 fn identity(input: String) -> Result<String> {

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, path::PathBuf};
+use std::{path::PathBuf, str::FromStr};
 
 use clap::Args;
 use eyre::{eyre, Result};
@@ -130,7 +130,8 @@ pub async fn write_rockspec(cli_flags: WriteRockspec) -> Result<()> {
         cli_flags.lua_versions,
         cli_flags.maintainer,
     ) {
-        ( // If all parameters are provided then don't bother prompting the user
+        // If all parameters are provided then don't bother prompting the user
+        (
             Some(name),
             Some(description),
             Some(labels),

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -122,28 +122,31 @@ fn parse_version(input: String) -> Result<LuaDependency> {
 }
 
 pub async fn write_rockspec(cli_flags: WriteRockspec) -> Result<()> {
-    let (package_name, description, labels, license, lua_versions, maintainer) = match (
-        cli_flags.name,
-        cli_flags.description,
-        cli_flags.labels,
-        cli_flags.license,
-        cli_flags.lua_versions,
-        cli_flags.maintainer,
-    ) {
+    let (package_name, description, labels, license, lua_versions, maintainer) = match cli_flags {
         // If all parameters are provided then don't bother prompting the user
-        (
-            Some(name),
-            Some(description),
-            Some(labels),
-            Some(license),
-            Some(lua_versions),
-            Some(maintainer),
-        ) => Ok::<_, eyre::Report>((name, description, labels, license, lua_versions, maintainer)),
-        (name, description, labels, license, lua_versions, maintainer) => {
+        WriteRockspec {
+            name: Some(name),
+            description: Some(description),
+            labels: Some(labels),
+            license: Some(license),
+            lua_versions: Some(lua_versions),
+            maintainer: Some(maintainer),
+            ..
+        } => Ok::<_, eyre::Report>((name, description, labels, license, lua_versions, maintainer)),
+
+        WriteRockspec {
+            name,
+            description,
+            labels,
+            license,
+            lua_versions,
+            maintainer,
+            directory,
+        } => {
             let mut spinner =
                 Spinner::new(Spinners::Dots, "Fetching repository metadata...".into());
 
-            let repo_metadata = github_metadata::get_metadata_for(cli_flags.directory.as_ref())
+            let repo_metadata = github_metadata::get_metadata_for(directory.as_ref())
                 .await?
                 .unwrap_or_else(|| RepoMetadata {
                     name: std::env::current_dir()

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -99,7 +99,7 @@ fn parse_list(input: String) -> Result<Vec<String>> {
     {
         Err(eyre!("Unexpected punctuation '{}' found at column {}. Lists are comma separated but names should not contain punctuation!", char, pos))
     } else {
-        Ok(input.split(",").map(|str| str.trim().to_string()).collect())
+        Ok(input.split(',').map(|str| str.trim().to_string()).collect())
     }
 }
 

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, path::PathBuf};
 
 use clap::Args;
 use eyre::{eyre, Result};
@@ -41,12 +41,15 @@ macro_rules! parse {
 
 // General notes and ideas:
 // - Should we require the user to create a "project" in order to use this command?
-// - Ask user for a homepage
 // - Automatically detect build type by inspecting the current repo (is there a Cargo.toml? is
 //   there something that tells us it's a lua project?).
+// - If repo metadata couldn't be fetched then don't error, simply don't provide default values.
 
 #[derive(Args)]
 pub struct WriteRockspec {
+    /// The directory of the rock.
+    directory: Option<PathBuf>,
+
     /// The name to give to the rock.
     #[arg(long)]
     name: Option<String>,
@@ -118,132 +121,151 @@ fn parse_version(input: String) -> Result<LuaDependency> {
     LuaDependency::from_str(format!("lua {}", input).as_str())
 }
 
-pub async fn write_rockspec(data: WriteRockspec) -> Result<()> {
-    let mut spinner = Spinner::new(Spinners::Dots, "Fetching repository metadata...".into());
+pub async fn write_rockspec(cli_flags: WriteRockspec) -> Result<()> {
+    let (package_name, description, labels, license, lua_versions, maintainer) = match (
+        cli_flags.name,
+        cli_flags.description,
+        cli_flags.labels,
+        cli_flags.license,
+        cli_flags.lua_versions,
+        cli_flags.maintainer,
+    ) {
+        ( // If all parameters are provided then don't bother prompting the user
+            Some(name),
+            Some(description),
+            Some(labels),
+            Some(license),
+            Some(lua_versions),
+            Some(maintainer),
+        ) => Ok::<_, eyre::Report>((name, description, labels, license, lua_versions, maintainer)),
+        (name, description, labels, license, lua_versions, maintainer) => {
+            let mut spinner =
+                Spinner::new(Spinners::Dots, "Fetching repository metadata...".into());
 
-    // [data.labels, data.license].into_iter().all(Option::is_some);
+            let repo_metadata = github_metadata::get_metadata_for(cli_flags.directory.as_ref())
+                .await?
+                .unwrap_or_else(|| RepoMetadata {
+                    name: std::env::current_dir()
+                        .expect("unable to get current working directory")
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string(),
+                    description: None,
+                    license: None,
+                    contributors: vec![users::get_current_username()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string()],
+                    labels: None,
+                });
 
-    let repo_metadata = github_metadata::get_metadata_for(None)
-        .await?
-        .unwrap_or_else(|| RepoMetadata {
-            name: std::env::current_dir()
-                .expect("unable to get current working directory")
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-            description: None,
-            license: None,
-            contributors: vec![users::get_current_username()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string()],
-            labels: None,
-        });
+            spinner.stop();
 
-    spinner.stop();
+            let mut editor = rustyline::Editor::<(), _>::new()?;
 
-    let mut editor = rustyline::Editor::<(), _>::new()?;
+            // TODO: Make prompts coloured
 
-    // TODO: Make prompts coloured
+            // let mut stdout = BufferedStandardStream::stdout(ColorChoice::Always);
+            // stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
 
-    // let mut stdout = BufferedStandardStream::stdout(ColorChoice::Always);
-    // stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
-
-    let package_name = data.name.map(Ok).unwrap_or_else(|| {
-        parse!(
-            editor
-                .readline(format!("Package Name (empty for '{}'): ", repo_metadata.name).as_str()),
-            identity,
-            repo_metadata.name
-        )
-    })?;
-
-    let description = data.description.map(Ok).unwrap_or_else(|| {
-        parse!(
-            editor.readline(
-                format!(
-                    "Description (empty for '{}'): ",
-                    repo_metadata
-                        .description
-                        .as_ref()
-                        .unwrap_or(&"*** enter a description ***".to_string())
+            let package_name = name.map(Ok).unwrap_or_else(|| {
+                parse!(
+                    editor.readline(
+                        format!("Package Name (empty for '{}'): ", repo_metadata.name).as_str()
+                    ),
+                    identity,
+                    repo_metadata.name
                 )
-                .as_str()
-            ),
-            identity,
-            repo_metadata.description.unwrap_or_default()
-        )
-    })?;
+            })?;
 
-    let license = data
-        .license // First validate the `--license` option
-        .map(Ok)
-        .unwrap_or_else(|| {
-            // If there was no `--license` then prompt the user
-            parse!(
-                editor.readline(
-                    format!(
-                        "License (empty for '{}', 'none' for no license): ",
-                        repo_metadata
-                            .license
-                            .as_ref()
-                            .unwrap_or(&"none".to_string())
+            let description = description.map(Ok).unwrap_or_else(|| {
+                parse!(
+                    editor.readline(
+                        format!(
+                            "Description (empty for '{}'): ",
+                            repo_metadata
+                                .description
+                                .as_ref()
+                                .unwrap_or(&"*** enter a description ***".to_string())
+                        )
+                        .as_str()
+                    ),
+                    identity,
+                    repo_metadata.description.unwrap_or_default()
+                )
+            })?;
+
+            let license = license // First validate the `--license` option
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    // If there was no `--license` then prompt the user
+                    parse!(
+                        editor.readline(
+                            format!(
+                                "License (empty for '{}', 'none' for no license): ",
+                                repo_metadata
+                                    .license
+                                    .as_ref()
+                                    .unwrap_or(&"none".to_string())
+                            )
+                            .as_str()
+                        ),
+                        parse_license,
+                        parse_license(repo_metadata.license.unwrap())?
                     )
-                    .as_str()
-                ),
-                parse_license,
-                parse_license(repo_metadata.license.unwrap())?
-            )
-        })?
-        .map(|license| license.name)
-        .unwrap_or("*** enter a license ***");
+                })?;
 
-    let maintainer = data.maintainer.map(Ok).unwrap_or_else(|| {
-        parse!(
-            editor.readline(
-                format!(
-                    "Maintainer (empty for '{}'): ",
+            let maintainer = maintainer.map(Ok).unwrap_or_else(|| {
+                parse!(
+                    editor.readline(
+                        format!(
+                            "Maintainer (empty for '{}'): ",
+                            repo_metadata.contributors.first().unwrap_or(&"".into())
+                        )
+                        .as_str()
+                    ),
+                    identity,
                     repo_metadata.contributors.first().unwrap_or(&"".into())
                 )
-                .as_str()
-            ),
-            identity,
-            repo_metadata.contributors.first().unwrap_or(&"".into())
-        )
-    })?;
+            })?;
 
-    let labels = data
-        .labels
-        .map(Ok)
-        .unwrap_or_else(|| {
-            parse!(
-                editor.readline(
-                    format!(
-                        "Labels (empty for '[{}]'): ",
-                        repo_metadata
-                            .labels
-                            .as_ref()
-                            .unwrap_or(&Vec::default())
-                            .join(" ")
-                    )
-                    .as_str()
-                ),
-                parse_list,
-                repo_metadata.labels.unwrap_or_default()
-            )
-        })?
-        .into_iter()
-        .map(|label| "\"".to_string() + &label + "\"")
-        .join(", ");
+            let labels = labels.map(Ok).unwrap_or_else(|| {
+                parse!(
+                    editor.readline(
+                        format!(
+                            "Labels (empty for '[{}]'): ",
+                            repo_metadata
+                                .labels
+                                .as_ref()
+                                .unwrap_or(&Vec::default())
+                                .join(" ")
+                        )
+                        .as_str()
+                    ),
+                    parse_list,
+                    repo_metadata.labels.unwrap_or_default()
+                )
+            })?;
 
-    let lua_versions = data.lua_versions.map(Ok).unwrap_or_else(|| {
-        parse!(
-            editor.readline("Supported Lua Versions (empty for '>= 5.1'): ",),
-            parse_version,
-            LuaDependency::from_str("lua >= 5.1")?
-        )
-    })?;
+            let lua_versions = lua_versions.map(Ok).unwrap_or_else(|| {
+                parse!(
+                    editor.readline("Supported Lua Versions (empty for '>= 5.1'): ",),
+                    parse_version,
+                    LuaDependency::from_str("lua >= 5.1")?
+                )
+            })?;
+
+            Ok((
+                package_name,
+                description,
+                labels,
+                license,
+                lua_versions,
+                maintainer,
+            ))
+        }
+    }?;
 
     std::fs::write(
         format!("{}-dev.rockspec", package_name),
@@ -274,8 +296,13 @@ build = {{
     "#,
             package_name = package_name,
             summary = description,
-            license = license,
-            labels = labels,
+            license = license
+                .map(|license| license.name)
+                .unwrap_or("*** enter a license ***"),
+            labels = labels
+                .into_iter()
+                .map(|label| "\"".to_string() + &label + "\"")
+                .join(", "),
             maintainer = maintainer,
             version = lua_versions.rock_version_req.to_string().replace('^', "~>"),
         )

--- a/rocks-bin/src/rockspec/write_rockspec.rs
+++ b/rocks-bin/src/rockspec/write_rockspec.rs
@@ -5,13 +5,15 @@ use spinners::{Spinner, Spinners};
 use crate::rockspec::github_metadata::{self, RepoMetadata};
 
 macro_rules! empty_or {
-    ($initial:expr, $alternative:expr) => {
-        if $initial.is_empty() {
+    ($initial:expr, $alternative:expr) => {{
+        let check = $initial;
+
+        if check.is_empty() {
             $alternative.into()
         } else {
-            $initial
+            check
         }
-    };
+    }};
 }
 
 // General notes and ideas:

--- a/rocks-lib/src/rockspec/dependency.rs
+++ b/rocks-lib/src/rockspec/dependency.rs
@@ -9,8 +9,8 @@ use super::{PartialOverride, PerPlatform, PlatformOverridable};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LuaDependency {
-    rock_name: String,
-    rock_version_req: VersionReq,
+    pub rock_name: String,
+    pub rock_version_req: VersionReq,
 }
 
 impl FromStr for LuaDependency {


### PR DESCRIPTION
This PR adds luarocks's `write-rockspec` command with quite a few tweaks.

This PR adds npm/yarn-like prompts for building up a rockspec file for a given project. It pulls any metadata it might need from either github or the local git repo to provide sane defaults :)