### PR TITLE
refactor: move Luarock class into separate file

### DIFF
--- a/rocks-lib/src/lib.rs
+++ b/rocks-lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod config;
+pub mod luarock;
 pub mod manifest;
 pub mod rocks;
 pub mod rockspec;

--- a/rocks-lib/src/luarock/mod.rs
+++ b/rocks-lib/src/luarock/mod.rs
@@ -1,0 +1,19 @@
+use semver::{Error, Version};
+
+mod version;
+
+pub use version::{parse_version, parse_version_req};
+
+pub struct LuaRock {
+    pub name: String,
+    pub version: Version,
+}
+
+impl LuaRock {
+    pub fn new(name: String, version: String) -> Result<Self, Error> {
+        Ok(Self {
+            name,
+            version: parse_version(&version)?,
+        })
+    }
+}

--- a/rocks-lib/src/luarock/version.rs
+++ b/rocks-lib/src/luarock/version.rs
@@ -1,0 +1,56 @@
+use eyre::Result;
+use html_escape::decode_html_entities;
+use semver::{Error, Version, VersionReq};
+
+/// Parses a Version from a string, automatically supplying any missing details (i.e. missing
+/// minor/patch sections).
+pub fn parse_version(s: &str) -> Result<Version, Error> {
+    Version::parse(&append_minor_patch_if_missing(s.to_string()))
+}
+
+/// Transform LuaRocks constraints into constraints that can be parsed by the semver crate.
+pub fn parse_version_req(version_constraints: &str) -> Result<VersionReq, Error> {
+    let unescaped = decode_html_entities(version_constraints)
+        .to_string()
+        .as_str()
+        .to_owned();
+    let transformed = match unescaped {
+        s if s.starts_with("~>") => parse_pessimistic_version_constraint(s)?,
+        s => s,
+    };
+
+    let version_req = VersionReq::parse(&transformed)?;
+    Ok(version_req)
+}
+
+fn parse_pessimistic_version_constraint(version_constraint: String) -> Result<String, Error> {
+    // pessimistic operator
+    let min_version_str = &version_constraint[2..].trim();
+    let min_version = Version::parse(&append_minor_patch_if_missing(min_version_str.to_string()))?;
+
+    let max_version = match min_version_str.matches('.').count() {
+        0 => Version {
+            major: &min_version.major + 1,
+            ..min_version.clone()
+        },
+        1 => Version {
+            minor: &min_version.minor + 1,
+            ..min_version.clone()
+        },
+        _ => Version {
+            patch: &min_version.patch + 1,
+            ..min_version.clone()
+        },
+    };
+
+    Ok(format!(">= {min_version}, < {max_version}"))
+}
+
+/// Recursively append .0 until the version string has a minor or patch version
+fn append_minor_patch_if_missing(version: String) -> String {
+    if version.matches('.').count() < 2 {
+        append_minor_patch_if_missing(version + ".0")
+    } else {
+        version
+    }
+}

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -122,7 +122,8 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use crate::rockspec::{LuaRock, PlatformIdentifier};
+    use crate::luarock::LuaRock;
+    use crate::rockspec::PlatformIdentifier;
 
     use super::*;
 


### PR DESCRIPTION
This PR attempts to refactor the components of `rockspec/dependency.rs`.

Question: does `LuaDependency` also theoretically counts as a "luarock", but I've decided to keep that in the old `dependency.rs` file, which I feel makes sense. Feedback is welcome on this.