### PR TITLE
fix: make clippy happy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "tokio",
  "vfs",
  "walkdir",
+ "which",
  "zip",
 ]
 
@@ -3272,6 +3273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,6 +3472,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "xxhash-rust"

--- a/rocks-lib/Cargo.toml
+++ b/rocks-lib/Cargo.toml
@@ -30,6 +30,7 @@ vfs = "0.12.0"
 walkdir = "2.4.0"
 zip = "0.6.6"
 insta = { version = "1.39.0", features = ["redactions", "yaml"] }
+which = "6.0.3"
 
 [dev-dependencies]
 httptest = { version = "0.15.5" }

--- a/rocks-lib/src/rockspec/platform.rs
+++ b/rocks-lib/src/rockspec/platform.rs
@@ -50,17 +50,17 @@ impl PartialOrd for PlatformIdentifier {
 
 /// Retrieves the target compilation platform and returns it as an identifier.
 pub fn get_platform() -> PlatformIdentifier {
-    if cfg!(linux) {
+    if cfg!(target_os = "linux") {
         PlatformIdentifier::Linux
-    } else if cfg!(macos) {
+    } else if cfg!(target_os = "macos") {
         PlatformIdentifier::MacOSX
-    } else if cfg!(cygwin) {
-        PlatformIdentifier::Cygwin
-    } else if cfg!(freebsd) {
+    } else if cfg!(target_os = "freebsd") {
         PlatformIdentifier::FreeBSD
+    } else if which::which("cygpath").is_ok() {
+        PlatformIdentifier::Cygwin
     } else if cfg!(unix) {
         PlatformIdentifier::Unix
-    } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86") {
+    } else if cfg!(all(target_os = "windows", target_arch = "x86")) {
         PlatformIdentifier::Win32
     } else if cfg!(windows) {
         PlatformIdentifier::Windows


### PR DESCRIPTION
This PR fixes clippy's complaints about invalid target OS checks. As it turns out, checking for cygwin is not a simple task, but is there any reason that we should check for cygwin explicitly?