### PR TITLE
fix: allow `rock == version` parsing in rockspecs

### DIFF
--- a/rocks-lib/src/luarock/version.rs
+++ b/rocks-lib/src/luarock/version.rs
@@ -16,6 +16,8 @@ pub fn parse_version_req(version_constraints: &str) -> Result<VersionReq, Error>
         .to_owned();
     let transformed = match unescaped {
         s if s.starts_with("~>") => parse_pessimistic_version_constraint(s)?,
+        // The semver crate only understands "= version", unlike luarocks which understands "== version".
+        s if s.starts_with("==") => s[1..].to_string(),
         s => s,
     };
 

--- a/rocks-lib/src/rockspec/dependency.rs
+++ b/rocks-lib/src/rockspec/dependency.rs
@@ -161,6 +161,12 @@ mod tests {
         assert!(!dep.matches(&neorg));
         let dep: LuaDependency = "neorg 2.0.0".parse().unwrap();
         assert!(dep.matches(&neorg));
+        let dep: LuaDependency = "neorg = 2.0.0".parse().unwrap();
+        assert!(dep.matches(&neorg));
+        let dep: LuaDependency = "neorg == 2.0.0".parse().unwrap();
+        assert!(dep.matches(&neorg));
+        let dep: LuaDependency = "neorg &equals; 2.0.0".parse().unwrap();
+        assert!(dep.matches(&neorg));
         let dep: LuaDependency = "neorg >= 1.0, &lt; 2.0".parse().unwrap();
         let neorg = LuaRock::new("neorg".into(), "1.5".into()).unwrap();
         assert!(dep.matches(&neorg));


### PR DESCRIPTION
fixes #37. This allows the deserialization of `rock == version` in rockspecs.