### PR TITLE
feat: project-local rocktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /rocks-lib/proptest-regressions/
 /*.rockspec
 *.snap.new
+/.rocks

--- a/rocks-bin/src/build.rs
+++ b/rocks-bin/src/build.rs
@@ -11,7 +11,7 @@ pub struct Build {
     rockspec_path: Option<PathBuf>,
 }
 
-pub fn build(data: Build, config: &Config) -> Result<()> {
+pub fn build(data: Build, config: Config) -> Result<()> {
     let rockspec_path = data.rockspec_path.map_or_else(|| {
         // Try to infer the rockspec the user meant.
 
@@ -48,7 +48,7 @@ pub fn build(data: Build, config: &Config) -> Result<()> {
     let rockspec = std::fs::read_to_string(rockspec_path)?;
     let rockspec = Rockspec::new(&rockspec)?;
 
-    rocks_lib::build::build(rockspec, config)?;
+    rocks_lib::build::build(rockspec, &config)?;
 
     Ok(())
 }

--- a/rocks-bin/src/download.rs
+++ b/rocks-bin/src/download.rs
@@ -8,10 +8,10 @@ pub struct Download {
     package_req: LuaPackageReq,
 }
 
-pub async fn download(dl_data: Download, config: &Config) -> Result<()> {
+pub async fn download(dl_data: Download, config: Config) -> Result<()> {
     println!("Downloading {}...", dl_data.package_req.name());
 
-    let rock = rocks_lib::operations::download(&dl_data.package_req, None, config).await?;
+    let rock = rocks_lib::operations::download(&dl_data.package_req, None, &config).await?;
 
     println!("Succesfully downloaded {}@{}", rock.name, rock.version);
 

--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -7,7 +7,7 @@ pub struct Install {
     package_req: LuaPackageReq,
 }
 
-pub async fn install(install_data: Install, config: &Config) -> Result<()> {
+pub async fn install(install_data: Install, config: Config) -> Result<()> {
     // TODO(vhyrro): If the tree doesn't exist then error out.
-    rocks_lib::operations::install(install_data.package_req, config).await
+    rocks_lib::operations::install(install_data.package_req, &config).await
 }

--- a/rocks-bin/src/install_lua.rs
+++ b/rocks-bin/src/install_lua.rs
@@ -4,8 +4,7 @@ use rocks_lib::{config::Config, lua_installation::LuaInstallation};
 pub fn install_lua(config: Config) -> Result<()> {
     // TODO: Make a single, monolithic getter for the lua version that returns a Result<>
     let version_stringified = config
-        .lua_version
-        .as_ref()
+        .lua_version()
         .ok_or_eyre("lua version not set! Please provide it via `--lua-version`.")?;
 
     // TODO: Detect when path already exists by checking `Lua::path()` and prompt the user

--- a/rocks-bin/src/install_lua.rs
+++ b/rocks-bin/src/install_lua.rs
@@ -1,7 +1,7 @@
 use eyre::{OptionExt, Result};
 use rocks_lib::{config::Config, lua_installation::LuaInstallation};
 
-pub fn install_lua(config: &Config) -> Result<()> {
+pub fn install_lua(config: Config) -> Result<()> {
     // TODO: Make a single, monolithic getter for the lua version that returns a Result<>
     let version_stringified = config
         .lua_version
@@ -10,7 +10,7 @@ pub fn install_lua(config: &Config) -> Result<()> {
 
     // TODO: Detect when path already exists by checking `Lua::path()` and prompt the user
     // whether they'd like to forcefully reinstall.
-    LuaInstallation::new(version_stringified, config)?;
+    LuaInstallation::new(version_stringified, &config)?;
 
     print!("Succesfully installed Lua {version_stringified}.");
 

--- a/rocks-bin/src/list.rs
+++ b/rocks-bin/src/list.rs
@@ -10,13 +10,10 @@ pub struct ListCmd {
     porcelain: bool,
 }
 
-pub fn list_installed(list_data: ListCmd, config: &Config) -> Result<()> {
+pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
     let tree = Tree::new(
-        &config.tree,
-        config
-            .lua_version
-            .as_ref()
-            .ok_or_eyre("lua version not supplied!")?,
+        config.tree,
+        config.lua_version.ok_or_eyre("lua version not supplied!")?,
     )?;
     let available_rocks = tree.list();
 

--- a/rocks-bin/src/list.rs
+++ b/rocks-bin/src/list.rs
@@ -12,8 +12,11 @@ pub struct ListCmd {
 
 pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
     let tree = Tree::new(
-        config.tree,
-        config.lua_version.ok_or_eyre("lua version not supplied!")?,
+        config.tree().clone(),
+        config
+            .lua_version()
+            .cloned()
+            .ok_or_eyre("lua version not supplied!")?,
     )?;
     let available_rocks = tree.list();
 

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -142,23 +142,23 @@ enum Commands {
 async fn main() {
     let cli = Cli::parse();
 
-    let default_config = Config::default();
-    let config = Config {
-        enable_development_rockspecs: cli.dev,
-        lua_dir: cli.lua_dir.unwrap_or(default_config.lua_dir),
-        lua_version: cli.lua_version.or(default_config.lua_version),
-        namespace: cli.namespace.unwrap_or(default_config.namespace),
-        only_server: cli.only_server.or(default_config.only_server),
-        only_sources: cli.only_sources.or(default_config.only_sources),
-        server: cli.server.unwrap_or(default_config.server),
-        tree: cli.tree.unwrap_or(default_config.tree),
-        timeout: cli
-            .timeout
-            .map(|duration| Duration::from_secs(duration as u64))
-            .unwrap_or(default_config.timeout),
-        no_project: cli.no_project,
-        verbose: cli.verbose,
-    };
+    let config = Config::new()
+        .dev(Some(cli.dev))
+        .lua_dir(cli.lua_dir)
+        .lua_version(cli.lua_version)
+        .namespace(cli.namespace)
+        .only_server(cli.only_server)
+        .only_sources(cli.only_sources)
+        .server(cli.server)
+        .tree(cli.tree)
+        .timeout(
+            cli.timeout
+                .map(|duration| Duration::from_secs(duration as u64)),
+        )
+        .no_project(Some(cli.no_project))
+        .verbose(Some(cli.verbose))
+        .build()
+        .unwrap();
 
     match cli.command {
         Some(command) => match command {

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -142,22 +142,23 @@ enum Commands {
 async fn main() {
     let cli = Cli::parse();
 
-    let config = Config::new()
-        .dev(cli.dev)
-        .lua_dir(cli.lua_dir)
-        .lua_version(cli.lua_version)
-        .namespace(cli.namespace)
-        .only_server(cli.only_server)
-        .only_sources(cli.only_sources)
-        .server(cli.server)
-        .tree(cli.tree)
-        // .cache_path(cli.cache_path)
-        .timeout(
-            cli.timeout
-                .map(|duration| Duration::from_secs(duration as u64)),
-        )
-        .no_project(cli.no_project)
-        .verbose(cli.verbose);
+    let default_config = Config::default();
+    let config = Config {
+        enable_development_rockspecs: cli.dev,
+        lua_dir: cli.lua_dir.unwrap_or(default_config.lua_dir),
+        lua_version: cli.lua_version.or(default_config.lua_version),
+        namespace: cli.namespace.unwrap_or(default_config.namespace),
+        only_server: cli.only_server.or(default_config.only_server),
+        only_sources: cli.only_sources.or(default_config.only_sources),
+        server: cli.server.unwrap_or(default_config.server),
+        tree: cli.tree.unwrap_or(default_config.tree),
+        timeout: cli
+            .timeout
+            .map(|duration| Duration::from_secs(duration as u64))
+            .unwrap_or(default_config.timeout),
+        no_project: cli.no_project,
+        verbose: cli.verbose,
+    };
 
     match cli.command {
         Some(command) => match command {
@@ -175,11 +176,11 @@ async fn main() {
                 .await
                 .unwrap(),
             Commands::Build(build_data) => build::build(build_data, &config).unwrap(),
-            Commands::List(list_data) => list::list_installed(list_data, &config).unwrap(),
+            Commands::List(list_data) => list::list_installed(list_data, config).unwrap(),
             Commands::Install(install_data) => {
                 install::install(install_data, &config).await.unwrap()
             }
-            Commands::Outdated(outdated) => outdated::outdated(outdated, &config).await.unwrap(),
+            Commands::Outdated(outdated) => outdated::outdated(outdated, config).await.unwrap(),
             Commands::InstallLua => install_lua::install_lua(&config).unwrap(),
             _ => unimplemented!(),
         },

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -162,26 +162,26 @@ async fn main() {
 
     match cli.command {
         Some(command) => match command {
-            Commands::Search(search_data) => search::search(search_data, &config).await.unwrap(),
+            Commands::Search(search_data) => search::search(search_data, config).await.unwrap(),
             Commands::Download(download_data) => {
-                download::download(download_data, &config).await.unwrap()
+                download::download(download_data, config).await.unwrap()
             }
             Commands::Debug(debug) => match debug {
                 Debug::Unpack(unpack_data) => unpack::unpack(unpack_data).await.unwrap(),
                 Debug::UnpackRemote(unpack_data) => {
-                    unpack::unpack_remote(unpack_data, &config).await.unwrap()
+                    unpack::unpack_remote(unpack_data, config).await.unwrap()
                 }
             },
             Commands::New(project_data) => project::write_new::write_project_rockspec(project_data)
                 .await
                 .unwrap(),
-            Commands::Build(build_data) => build::build(build_data, &config).unwrap(),
+            Commands::Build(build_data) => build::build(build_data, config).unwrap(),
             Commands::List(list_data) => list::list_installed(list_data, config).unwrap(),
             Commands::Install(install_data) => {
-                install::install(install_data, &config).await.unwrap()
+                install::install(install_data, config).await.unwrap()
             }
             Commands::Outdated(outdated) => outdated::outdated(outdated, config).await.unwrap(),
-            Commands::InstallLua => install_lua::install_lua(&config).unwrap(),
+            Commands::InstallLua => install_lua::install_lua(config).unwrap(),
             _ => unimplemented!(),
         },
         None => {

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -8,7 +8,7 @@ use download::Download;
 use install::Install;
 use list::ListCmd;
 use outdated::Outdated;
-use rocks_lib::config::{Config, LuaVersion};
+use rocks_lib::config::{ConfigBuilder, LuaVersion};
 use search::Search;
 use update::Update;
 
@@ -142,7 +142,7 @@ enum Commands {
 async fn main() {
     let cli = Cli::parse();
 
-    let config = Config::new()
+    let config = ConfigBuilder::new()
         .dev(Some(cli.dev))
         .lua_dir(cli.lua_dir)
         .lua_version(cli.lua_version)

--- a/rocks-bin/src/outdated.rs
+++ b/rocks-bin/src/outdated.rs
@@ -16,17 +16,18 @@ pub struct Outdated {
     porcelain: bool,
 }
 
-pub async fn outdated(outdated_data: Outdated, config: &Config) -> Result<()> {
+pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
+    let manifest = manifest_from_server(config.server.to_owned(), &config).await?;
+
     // TODO: Don't perform error checks everywhere, instead add a single function that ensures a
     // version is set.
     let tree = Tree::new(
-        &config.tree,
-        config.lua_version.as_ref().ok_or_eyre(
+        config.tree,
+        config.lua_version.ok_or_eyre(
             "lua version not set. You can supply it via '--lua-version' or set it in the config.",
         )?,
     )?;
 
-    let manifest = manifest_from_server(config.server.to_owned(), config).await?;
     let metadata = ManifestMetadata::new(&manifest)?;
 
     // NOTE: This will display all installed versions and each possible upgrade.

--- a/rocks-bin/src/outdated.rs
+++ b/rocks-bin/src/outdated.rs
@@ -17,13 +17,13 @@ pub struct Outdated {
 }
 
 pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
-    let manifest = manifest_from_server(config.server.to_owned(), &config).await?;
+    let manifest = manifest_from_server(config.server().clone(), &config).await?;
 
     // TODO: Don't perform error checks everywhere, instead add a single function that ensures a
     // version is set.
     let tree = Tree::new(
-        config.tree,
-        config.lua_version.ok_or_eyre(
+        config.tree().clone(),
+        config.lua_version().cloned().ok_or_eyre(
             "lua version not set. You can supply it via '--lua-version' or set it in the config.",
         )?,
     )?;

--- a/rocks-bin/src/project/write_new.rs
+++ b/rocks-bin/src/project/write_new.rs
@@ -263,6 +263,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject) -> Result<()> {
             r#"
 rockspec_format = "3.0"
 package = "{package_name}"
+version = "0.1.0"
 
 source = {{
     url = "*** provide a url here ***",

--- a/rocks-bin/src/project/write_new.rs
+++ b/rocks-bin/src/project/write_new.rs
@@ -101,7 +101,7 @@ fn validate_license(input: &str) -> std::result::Result<Validation, Box<dyn Erro
 }
 
 pub async fn write_project_rockspec(cli_flags: NewProject) -> Result<()> {
-    let project = Project::new(None)?;
+    let project = Project::current()?;
     let render_config = RenderConfig::default_colored()
         .with_prompt_prefix(Styled::new(">").with_fg(inquire::ui::Color::LightGreen));
 

--- a/rocks-bin/src/search.rs
+++ b/rocks-bin/src/search.rs
@@ -24,7 +24,7 @@ pub struct Search {
 pub async fn search(data: Search, config: Config) -> Result<()> {
     let formatting = TreeFormatting::dir_tree(FormatCharacters::box_chars());
 
-    let manifest = manifest_from_server(config.server.to_owned(), &config).await?;
+    let manifest = manifest_from_server(config.server().clone(), &config).await?;
 
     let metadata = ManifestMetadata::new(&manifest)?;
 

--- a/rocks-bin/src/search.rs
+++ b/rocks-bin/src/search.rs
@@ -21,10 +21,10 @@ pub struct Search {
     porcelain: bool,
 }
 
-pub async fn search(data: Search, config: &Config) -> Result<()> {
+pub async fn search(data: Search, config: Config) -> Result<()> {
     let formatting = TreeFormatting::dir_tree(FormatCharacters::box_chars());
 
-    let manifest = manifest_from_server(config.server.to_owned(), config).await?;
+    let manifest = manifest_from_server(config.server.to_owned(), &config).await?;
 
     let metadata = ManifestMetadata::new(&manifest)?;
 

--- a/rocks-bin/src/unpack.rs
+++ b/rocks-bin/src/unpack.rs
@@ -34,11 +34,11 @@ pub async fn unpack(data: Unpack) -> Result<()> {
     Ok(())
 }
 
-pub async fn unpack_remote(data: UnpackRemote, config: &Config) -> Result<()> {
+pub async fn unpack_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let package_req = data.package_req;
     println!("Downloading {}...", package_req.name());
 
-    let rock = rocks_lib::operations::download(&package_req, None, config).await?;
+    let rock = rocks_lib::operations::download(&package_req, None, &config).await?;
 
     println!("Unpacking {}...", rock.path.display());
 

--- a/rocks-lib/src/build/builtin.rs
+++ b/rocks-lib/src/build/builtin.rs
@@ -92,7 +92,7 @@ fn autodetect_modules() -> Result<HashMap<String, ModuleSpec>> {
 mod tests {
     use tempdir::TempDir;
 
-    use crate::{config::Config, rockspec::Rockspec};
+    use crate::{config::ConfigBuilder, rockspec::Rockspec};
 
     #[test]
     fn builtin_build() {
@@ -103,7 +103,7 @@ mod tests {
                 .unwrap();
         let rockspec = Rockspec::new(&content).unwrap();
 
-        let config = Config::new()
+        let config = ConfigBuilder::new()
             .tree(Some(dir.into_path()))
             .lua_version(Some(crate::config::LuaVersion::Lua51))
             .build()

--- a/rocks-lib/src/build/builtin.rs
+++ b/rocks-lib/src/build/builtin.rs
@@ -104,8 +104,8 @@ mod tests {
         let rockspec = Rockspec::new(&content).unwrap();
 
         let config = Config::new()
-            .tree(Some(dir.into_path()))
-            .lua_version(Some(crate::config::LuaVersion::Lua51));
+            .tree(dir.into_path())
+            .lua_version(crate::config::LuaVersion::Lua51);
 
         crate::build::build(rockspec, &config).unwrap();
     }

--- a/rocks-lib/src/build/builtin.rs
+++ b/rocks-lib/src/build/builtin.rs
@@ -104,8 +104,10 @@ mod tests {
         let rockspec = Rockspec::new(&content).unwrap();
 
         let config = Config::new()
-            .tree(dir.into_path())
-            .lua_version(crate::config::LuaVersion::Lua51);
+            .tree(Some(dir.into_path()))
+            .lua_version(Some(crate::config::LuaVersion::Lua51))
+            .build()
+            .unwrap();
 
         crate::build::build(rockspec, &config).unwrap();
     }

--- a/rocks-lib/src/config/mod.rs
+++ b/rocks-lib/src/config/mod.rs
@@ -64,10 +64,6 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new() -> ConfigBuilder {
-        ConfigBuilder::default()
-    }
-
     pub fn get_project_dirs() -> Result<ProjectDirs> {
         directories::ProjectDirs::from("org", "neorocks", "rocks")
             .ok_or(eyre!("Could not find a valid home directory"))
@@ -147,61 +143,65 @@ pub struct ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    pub fn dev(self, dev: Option<bool>) -> ConfigBuilder {
-        ConfigBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn dev(self, dev: Option<bool>) -> Self {
+        Self {
             enable_development_rockspecs: dev,
             ..self
         }
     }
 
-    pub fn server(self, server: Option<String>) -> ConfigBuilder {
-        ConfigBuilder { server, ..self }
+    pub fn server(self, server: Option<String>) -> Self {
+        Self { server, ..self }
     }
 
-    pub fn only_server(self, server: Option<String>) -> ConfigBuilder {
-        ConfigBuilder {
+    pub fn only_server(self, server: Option<String>) -> Self {
+        Self {
             only_server: server.clone(),
             server,
             ..self
         }
     }
 
-    pub fn only_sources(self, sources: Option<String>) -> ConfigBuilder {
-        ConfigBuilder {
+    pub fn only_sources(self, sources: Option<String>) -> Self {
+        Self {
             only_sources: sources,
             ..self
         }
     }
 
-    pub fn namespace(self, namespace: Option<String>) -> ConfigBuilder {
-        ConfigBuilder { namespace, ..self }
+    pub fn namespace(self, namespace: Option<String>) -> Self {
+        Self { namespace, ..self }
     }
 
-    pub fn lua_dir(self, lua_dir: Option<PathBuf>) -> ConfigBuilder {
-        ConfigBuilder { lua_dir, ..self }
+    pub fn lua_dir(self, lua_dir: Option<PathBuf>) -> Self {
+        Self { lua_dir, ..self }
     }
 
-    pub fn lua_version(self, lua_version: Option<LuaVersion>) -> ConfigBuilder {
-        ConfigBuilder {
+    pub fn lua_version(self, lua_version: Option<LuaVersion>) -> Self {
+        Self {
             lua_version,
             ..self
         }
     }
 
-    pub fn tree(self, tree: Option<PathBuf>) -> ConfigBuilder {
-        ConfigBuilder { tree, ..self }
+    pub fn tree(self, tree: Option<PathBuf>) -> Self {
+        Self { tree, ..self }
     }
 
-    pub fn no_project(self, no_project: Option<bool>) -> ConfigBuilder {
-        ConfigBuilder { no_project, ..self }
+    pub fn no_project(self, no_project: Option<bool>) -> Self {
+        Self { no_project, ..self }
     }
 
-    pub fn verbose(self, verbose: Option<bool>) -> ConfigBuilder {
-        ConfigBuilder { verbose, ..self }
+    pub fn verbose(self, verbose: Option<bool>) -> Self {
+        Self { verbose, ..self }
     }
 
-    pub fn timeout(self, timeout: Option<Duration>) -> ConfigBuilder {
-        ConfigBuilder { timeout, ..self }
+    pub fn timeout(self, timeout: Option<Duration>) -> Self {
+        Self { timeout, ..self }
     }
 
     pub fn build(self) -> Result<Config> {
@@ -215,7 +215,7 @@ impl ConfigBuilder {
                 .unwrap_or_else(|| "https://luarocks.org/".to_string()),
             only_server: self.only_server,
             only_sources: self.only_sources,
-            namespace: self.namespace.unwrap_or_else(|| "".to_string()),
+            namespace: self.namespace.unwrap_or_default(),
             lua_dir: self.lua_dir.unwrap_or_else(|| data_path.join("lua")),
             lua_version: self.lua_version.or(current_project
                 .as_ref()

--- a/rocks-lib/src/lua_installation/mod.rs
+++ b/rocks-lib/src/lua_installation/mod.rs
@@ -65,6 +65,6 @@ impl LuaInstallation {
     }
 
     pub fn path(version: &LuaVersion, config: &Config) -> Result<PathBuf> {
-        Ok(config.lua_dir.join(version.to_string()))
+        Ok(config.lua_dir().join(version.to_string()))
     }
 }

--- a/rocks-lib/src/manifest/metadata.rs
+++ b/rocks-lib/src/manifest/metadata.rs
@@ -39,7 +39,8 @@ impl ManifestMetadata {
     }
 
     pub async fn from_config(config: &Config) -> Result<Self> {
-        let manifest = crate::manifest::manifest_from_server(config.server.clone(), config).await?;
+        let manifest =
+            crate::manifest::manifest_from_server(config.server().clone(), config).await?;
 
         Self::new(&manifest)
     }

--- a/rocks-lib/src/manifest/pull_manifest.rs
+++ b/rocks-lib/src/manifest/pull_manifest.rs
@@ -61,6 +61,8 @@ mod tests {
     use httptest::{matchers::*, responders::*, Expectation, Server};
     use serial_test::serial;
 
+    use crate::config::ConfigBuilder;
+
     use super::*;
 
     fn reset_cache() {
@@ -91,7 +93,7 @@ mod tests {
         let server = start_test_server("manifest".into());
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
-        let config = Config::new().build().unwrap();
+        let config = ConfigBuilder::new().build().unwrap();
         manifest_from_server(url_str, &config).await.unwrap();
     }
 
@@ -103,7 +105,7 @@ mod tests {
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
 
-        let config = Config::new()
+        let config = ConfigBuilder::new()
             .lua_version(Some(crate::config::LuaVersion::Lua51))
             .build()
             .unwrap();
@@ -119,7 +121,7 @@ mod tests {
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
         let manifest_content = "dummy data";
-        let config = Config::new().build().unwrap();
+        let config = ConfigBuilder::new().build().unwrap();
         let cache_dir = Config::get_default_cache_path().unwrap();
         let cache = cache_dir.join("manifest");
         fs::write(&cache, manifest_content).unwrap();

--- a/rocks-lib/src/manifest/pull_manifest.rs
+++ b/rocks-lib/src/manifest/pull_manifest.rs
@@ -8,8 +8,7 @@ use crate::config::Config;
 pub async fn manifest_from_server(url: String, config: &Config) -> Result<String> {
     let manifest_filename = "manifest".to_string()
         + &config
-            .lua_version
-            .as_ref()
+            .lua_version()
             .map(|s| format!("-{}", s))
             .unwrap_or_default();
     let url = url.trim_end_matches('/').to_string() + "/" + &manifest_filename;
@@ -92,7 +91,7 @@ mod tests {
         let server = start_test_server("manifest".into());
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
-        let config = Config::default();
+        let config = Config::new().build().unwrap();
         manifest_from_server(url_str, &config).await.unwrap();
     }
 
@@ -104,10 +103,10 @@ mod tests {
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
 
-        let config = Config {
-            lua_version: Some(crate::config::LuaVersion::Lua51),
-            ..Config::default()
-        };
+        let config = Config::new()
+            .lua_version(Some(crate::config::LuaVersion::Lua51))
+            .build()
+            .unwrap();
 
         manifest_from_server(url_str, &config).await.unwrap();
     }
@@ -120,7 +119,7 @@ mod tests {
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
         let manifest_content = "dummy data";
-        let config = Config::default();
+        let config = Config::new().build().unwrap();
         let cache_dir = Config::get_default_cache_path().unwrap();
         let cache = cache_dir.join("manifest");
         fs::write(&cache, manifest_content).unwrap();

--- a/rocks-lib/src/operations/download.rs
+++ b/rocks-lib/src/operations/download.rs
@@ -26,7 +26,7 @@ pub async fn download(
         return Err(eyre!(format!(
             "Rock '{}' does not exist on {}'s manifest.",
             package_req.name(),
-            config.server
+            config.server()
         )));
     }
 
@@ -34,7 +34,7 @@ pub async fn download(
 
     let full_rock_name = format!("{}-{}.src.rock", package.name(), package.version());
 
-    let rock = reqwest::get(format!("{}/{}", config.server, full_rock_name))
+    let rock = reqwest::get(format!("{}/{}", config.server(), full_rock_name))
         .await?
         .bytes()
         .await?;

--- a/rocks-lib/src/project/mod.rs
+++ b/rocks-lib/src/project/mod.rs
@@ -1,9 +1,8 @@
 use eyre::Result;
 use lets_find_up::{find_up_with, FindUpKind, FindUpOptions};
-use std::{
-    borrow::Borrow,
-    path::{Path, PathBuf},
-};
+use std::
+    path::{Path, PathBuf}
+;
 
 use crate::{config::LuaVersion, rockspec::Rockspec, tree::Tree};
 
@@ -13,8 +12,6 @@ pub struct Project {
     root: PathBuf,
     /// The parsed rockspec.
     rockspec: Rockspec,
-    /// The tree of the project.
-    tree: Tree,
 }
 
 impl Project {
@@ -33,16 +30,12 @@ impl Project {
             Some(path) => {
                 let rockspec_content = std::fs::read_to_string(&path)?;
                 let rockspec = Rockspec::new(&rockspec_content)?;
-                // NOTE: This will error if the project doesn't specify a Lua dependency.
-                // Should we enforce `lua >= xyz` in our `project.rockspec`s?
-                let lua_version: LuaVersion = rockspec.borrow().try_into()?;
 
                 let root = path.parent().unwrap().to_path_buf().join(".rocks");
 
                 std::fs::create_dir_all(&root)?;
 
                 Ok(Some(Project {
-                    tree: Tree::new(root.join("tree"), lua_version)?,
                     root,
                     rockspec,
                 }))
@@ -61,8 +54,8 @@ impl Project {
         &self.rockspec
     }
 
-    pub fn tree(&self) -> &Tree {
-        &self.tree
+    pub fn tree(&self, lua_version: LuaVersion) -> Result<Tree> {
+        Tree::new(self.root.clone(), lua_version)
     }
 }
 

--- a/rocks-lib/src/project/mod.rs
+++ b/rocks-lib/src/project/mod.rs
@@ -1,8 +1,6 @@
 use eyre::Result;
 use lets_find_up::{find_up_with, FindUpKind, FindUpOptions};
-use std::
-    path::{Path, PathBuf}
-;
+use std::path::{Path, PathBuf};
 
 use crate::{config::LuaVersion, rockspec::Rockspec, tree::Tree};
 
@@ -35,10 +33,7 @@ impl Project {
 
                 std::fs::create_dir_all(&root)?;
 
-                Ok(Some(Project {
-                    root,
-                    rockspec,
-                }))
+                Ok(Some(Project { root, rockspec }))
             }
             None => Ok(None),
         }

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -16,7 +16,10 @@ pub use platform::*;
 pub use rock_source::*;
 pub use test_spec::*;
 
-use crate::lua_package::{LuaPackageReq, PackageName, PackageVersion};
+use crate::{
+    config::LuaVersion,
+    lua_package::{LuaPackageReq, PackageName, PackageVersion},
+};
 
 #[derive(Debug)]
 pub struct Rockspec {
@@ -80,6 +83,27 @@ impl Rockspec {
             }
         }
         Ok(rockspec)
+    }
+
+    pub fn lua_version(&self) -> Option<LuaVersion> {
+        self.dependencies
+            .current_platform()
+            .iter()
+            .find(|val| *val.name() == "lua".into())
+            .and_then(|lua| {
+                for (possibility, version) in [
+                    ("5.4.0", LuaVersion::Lua54),
+                    ("5.3.0", LuaVersion::Lua53),
+                    ("5.2.0", LuaVersion::Lua52),
+                    ("5.1.0", LuaVersion::Lua51),
+                ] {
+                    if lua.version_req().matches(&possibility.parse().unwrap()) {
+                        return Some(version);
+                    }
+                }
+
+                None
+            })
     }
 }
 

--- a/rocks-lib/src/tree/list.rs
+++ b/rocks-lib/src/tree/list.rs
@@ -8,7 +8,7 @@ use crate::lua_package::LuaPackage;
 
 use super::Tree;
 
-impl<'a> Tree<'a> {
+impl Tree {
     pub fn list(&self) -> HashMap<String, Vec<String>> {
         WalkDir::new(self.root())
             .min_depth(1)
@@ -42,10 +42,10 @@ impl<'a> Tree<'a> {
     }
 }
 
-impl<'a> TryFrom<Tree<'a>> for Vec<LuaPackage> {
+impl TryFrom<Tree> for Vec<LuaPackage> {
     type Error = eyre::Report;
 
-    fn try_from(tree: Tree<'a>) -> Result<Self> {
+    fn try_from(tree: Tree) -> Result<Self> {
         tree.into_rock_list()
     }
 }

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -19,11 +19,12 @@ mod list;
 /// - /rocks/<lua-version>/<rock>/src - library code for the rock
 /// - /bin - binary files produced by various rocks
 
-pub struct Tree<'a> {
+#[derive(Debug)]
+pub struct Tree {
     /// The Lua version of the tree.
-    version: &'a LuaVersion,
+    version: LuaVersion,
     /// The root of the tree.
-    root: &'a PathBuf,
+    root: PathBuf,
 }
 
 /// Change-agnostic way of referencing various paths for a rock.
@@ -34,8 +35,8 @@ pub struct RockLayout {
     pub src: PathBuf,
 }
 
-impl<'a> Tree<'a> {
-    pub fn new(root: &'a PathBuf, version: &'a LuaVersion) -> Result<Self> {
+impl Tree {
+    pub fn new(root: PathBuf, version: LuaVersion) -> Result<Self> {
         // Ensure that the root and the version directory exist.
         std::fs::create_dir_all(root.join(version.to_string()))?;
 
@@ -90,7 +91,7 @@ mod tests {
         let tree_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/sample-tree");
 
-        let tree = Tree::new(&tree_path, &LuaVersion::Lua51).unwrap();
+        let tree = Tree::new(tree_path.clone(), LuaVersion::Lua51).unwrap();
 
         let neorg = tree
             .rock(&"neorg".into(), &"8.0.0-1".parse().unwrap())

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -126,7 +126,7 @@ mod tests {
         let tree_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/sample-tree");
 
-        let tree = Tree::new(&tree_path, &LuaVersion::Lua51).unwrap();
+        let tree = Tree::new(tree_path, LuaVersion::Lua51).unwrap();
 
         assert_yaml_snapshot!(tree.list(), { "." => sorted_redaction() })
     }


### PR DESCRIPTION
 This is a draft implementation of project-local rock trees. If `rocks` detects it's in a project, it will always interact with the project-local rock tree first. Pass `--no-project` to prevent these interactions.