### PR TITLE
fix: remove unused `rocks init`

### DIFF
--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -103,8 +103,6 @@ enum Commands {
     Download(Download),
     /// Formats the codebase according to a `stylua.toml`.
     Fmt,
-    /// Initialize a directory for a Lua project using Rocks.
-    Init,
     /// Install a rock for use on the system.
     Install(Install),
     /// Manually install and manage Lua headers for various Lua versions.

--- a/rocks-lib/src/lua_package/outdated.rs
+++ b/rocks-lib/src/lua_package/outdated.rs
@@ -19,3 +19,25 @@ impl LuaPackage {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::{lua_package::LuaPackage, manifest::ManifestMetadata};
+
+    #[test]
+    fn rock_has_update() {
+        let test_manifest_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/manifest");
+        let manifest = String::from_utf8(std::fs::read(&test_manifest_path).unwrap()).unwrap();
+        let manifest = ManifestMetadata::new(&manifest).unwrap();
+
+        let test_package = LuaPackage::parse("lua-cjson".to_string(), "2.0.0".to_string()).unwrap();
+
+        assert_eq!(
+            test_package.has_update(&manifest).unwrap(),
+            Some("2.1.0-1".parse().unwrap())
+        );
+    }
+}


### PR DESCRIPTION
stacked on #67. the command is no longer necessary.