### PR TITLE
fix: version and rock name parsing errors (#79)

### DIFF
--- a/rocks-lib/src/lua_package/mod.rs
+++ b/rocks-lib/src/lua_package/mod.rs
@@ -8,7 +8,6 @@ pub use version::{PackageVersion, PackageVersionReq};
 mod outdated;
 mod version;
 
-// TODO: We probably need a better name for this
 pub struct LuaPackage {
     name: PackageName,
     version: PackageVersion,
@@ -75,7 +74,7 @@ impl FromStr for LuaPackageReq {
     fn from_str(str: &str) -> Result<Self> {
         let rock_name_str = str
             .chars()
-            .peeking_take_while(|t| t.is_alphanumeric() || matches!(t, '-' | '_'))
+            .peeking_take_while(|t| t.is_alphanumeric() || matches!(t, '-' | '_' | '.'))
             .collect::<String>();
 
         if rock_name_str.is_empty() {
@@ -199,6 +198,8 @@ mod tests {
         assert_eq!(package_req.name.to_string(), "lua");
         let package_req: LuaPackageReq = "toml-edit >= 0.1.0".parse().unwrap();
         assert_eq!(package_req.name.to_string(), "toml-edit");
+        let package_req: LuaPackageReq = "plugin.nvim >= 0.1.0".parse().unwrap();
+        assert_eq!(package_req.name.to_string(), "plugin.nvim");
         let package_req: LuaPackageReq = "lfs".parse().unwrap();
         assert_eq!(package_req.name.to_string(), "lfs");
         let package_req: LuaPackageReq = "neorg 1.0.0".parse().unwrap();

--- a/rocks-lib/src/manifest/metadata.rs
+++ b/rocks-lib/src/manifest/metadata.rs
@@ -72,9 +72,9 @@ impl ManifestMetadata {
 
         let version = self.repository[lua_package_req.name()]
             .keys()
-            .filter(|version| lua_package_req.version_req().matches(version))
             .sorted()
-            .last()?;
+            .rev()
+            .find_or_first(|version| lua_package_req.version_req().matches(version))?;
 
         Some(LuaPackage::new(
             lua_package_req.name().to_owned(),


### PR DESCRIPTION
This PR was supposed to be much longer, but I decided that we were layering on too much complexity with no benefit whatsoever.

This PR fixes #79 in two ways: firstly, it fixes the broken version checking code (and now defaults to the latest version correctly). Secondly, it permits rock names to now also have .s in their names.
Instead of trying to create a generic catch-all parser, I think restricting rocks to this format is both sane and expected. During the big error rewrite, we can issue nice error messages to the user so they're never confused.