### PR TITLE
ci: use magic-nix-cache-action for non release builds

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -17,11 +17,8 @@ jobs:
           - { os: macos-14, target: aarch64-darwin }
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@v9
-    - uses: cachix/cachix-action@v14
-      with:
-        name: neorocks
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Checks
       run: nix build ".#checks.${{matrix.job.target}}.git-hooks-check" --accept-flake-config --log-lines 500
       if: ${{ matrix.job.target == 'x86_64-linux' }}

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     name: ${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
+    permissions:
+      id-token: "write"
+      contents: "read"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This action uses GitHub's local cache, which gives us faster builds, but we can't fetch them locally.  I think this is a better choice for PR builds.