### PR TITLE
ci: build devShells on release build

### DIFF
--- a/.github/workflows/nix-release-build.yml
+++ b/.github/workflows/nix-release-build.yml
@@ -24,3 +24,6 @@ jobs:
     - name: Build package
       run: nix build ".#packages.${{matrix.job.target}}.default" -Lv --accept-flake-config
       shell: bash
+    - name: Build devShell
+      run: nix build ".#devShells.${{matrix.job.target}}.default" -Lv --accept-flake-config
+      shell: bash


### PR DESCRIPTION
With #84, we need to build the devShells here to have them available on cachix.