### PR TITLE
tests: separate integration tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
-tt = "nextest run --features=test_nosandbox"
+tt = "nextest run --tests --no-fail-fast" # All
+tl = "nextest run --lib --no-fail-fast" # Lib only

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+name: Integration tests
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Swatinem/rust-cache@v2
+      - name: Integration tests
+        run: | 
+          nix develop --command cargo nextest run --test "*"
+        shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,9 @@ nix build .#checks.<your-system>.git-hooks-check -Lv
 
 ## Running tests without nix
 
-For reproducibility, we only run tests that can be sandboxed in CI
-(or with nix).
-To run tests locally with non-sandboxed tests enabled:
-
-```bash
-cargo test --features=test_nosandbox
-```
+For reproducibility, we only run tests that can be sandboxed with nix,
+skipping integration tests.
+Running `cargo test` locally will run all tests, including integration tests.
 
 Or, if you are using [cargo-nextest](https://nexte.st/), we provide an alias:
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -29,10 +29,18 @@
 
         nativeCheckInputs = [
           cacert
+          cargo-nextest
         ];
 
         preCheck = ''
           export HOME=$(realpath .)
+        '';
+
+        checkPhase = ''
+          runHook preCheck
+          # Disable integration tests
+          cargo nextest run --no-fail-fast --lib
+          runHook postCheck
         '';
 
         env = {

--- a/rocks-lib/Cargo.toml
+++ b/rocks-lib/Cargo.toml
@@ -49,5 +49,4 @@ dir-diff = "0.3.3"
 insta = "1.39.0"
 
 [features]
-test_nosandbox = [] # Run tests without sandboxing
 clap = ["dep:clap"]

--- a/rocks-lib/src/build/builtin.rs
+++ b/rocks-lib/src/build/builtin.rs
@@ -86,29 +86,3 @@ fn autodetect_modules() -> Result<HashMap<String, ModuleSpec>> {
         })
         .try_collect()
 }
-
-#[cfg(test)]
-#[cfg(feature = "test_nosandbox")]
-mod tests {
-    use tempdir::TempDir;
-
-    use crate::{config::ConfigBuilder, rockspec::Rockspec};
-
-    #[tokio::test]
-    async fn builtin_build() {
-        let dir = TempDir::new("rocks-test").unwrap();
-
-        let content =
-            String::from_utf8(std::fs::read("resources/test/lua-cjson-2.1.0-1.rockspec").unwrap())
-                .unwrap();
-        let rockspec = Rockspec::new(&content).unwrap();
-
-        let config = ConfigBuilder::new()
-            .tree(Some(dir.into_path()))
-            .lua_version(Some(crate::config::LuaVersion::Lua51))
-            .build()
-            .unwrap();
-
-        crate::build::build(rockspec, &config).await.unwrap();
-    }
-}

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -91,7 +91,6 @@ impl Tree {
 mod tests {
     use std::path::PathBuf;
 
-    #[cfg(feature = "test_nosandbox")]
     use insta::{assert_yaml_snapshot, sorted_redaction};
 
     use crate::{config::LuaVersion, tree::RockLayout};
@@ -133,7 +132,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "test_nosandbox")]
     fn tree_list() {
         let tree_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/sample-tree");

--- a/rocks-lib/src/tree/snapshots/rocks_lib__tree__tests__tree_list.snap
+++ b/rocks-lib/src/tree/snapshots/rocks_lib__tree__tests__tree_list.snap
@@ -1,5 +1,6 @@
 ---
 source: rocks-lib/src/tree/mod.rs
+assertion_line: 141
 expression: tree.list()
 ---
 lua-cjson:

--- a/rocks-lib/tests/build.rs
+++ b/rocks-lib/tests/build.rs
@@ -1,0 +1,24 @@
+use rocks_lib::{
+    build,
+    config::{ConfigBuilder, LuaVersion},
+    rockspec::Rockspec,
+};
+use tempdir::TempDir;
+
+#[tokio::test]
+async fn builtin_build() {
+    let dir = TempDir::new("rocks-test").unwrap();
+
+    let content =
+        String::from_utf8(std::fs::read("resources/test/lua-cjson-2.1.0-1.rockspec").unwrap())
+            .unwrap();
+    let rockspec = Rockspec::new(&content).unwrap();
+
+    let config = ConfigBuilder::new()
+        .tree(Some(dir.into_path()))
+        .lua_version(Some(LuaVersion::Lua51))
+        .build()
+        .unwrap();
+
+    build::build(rockspec, &config).await.unwrap();
+}


### PR DESCRIPTION
This PR splits out the integration tests and adds a GH action for running them.
We only run the `--lib` tests in the Nix build.