### PR TITLE
feat(install): implement rockspec URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1383,6 +1394,15 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "infer"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]
@@ -2484,11 +2504,13 @@ dependencies = [
  "dir-diff",
  "directories",
  "eyre",
+ "flate2",
  "git-url-parse",
  "git2",
  "html-escape",
  "httpdate",
  "httptest",
+ "infer",
  "insta",
  "itertools",
  "lets_find_up",
@@ -2508,6 +2530,7 @@ dependencies = [
  "ssri",
  "strum 0.26.3",
  "strum_macros 0.26.4",
+ "tar",
  "target-lexicon",
  "tempdir",
  "tokio",
@@ -3184,6 +3207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,6 +3633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+
+[[package]]
 name = "uzers"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,6 +4024,17 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/rocks-lib/Cargo.toml
+++ b/rocks-lib/Cargo.toml
@@ -30,6 +30,8 @@ tempdir = "0.3.7"
 vfs = "0.12.0"
 walkdir = "2.4.0"
 zip = "2.2.0"
+tar = "0.4.42"
+flate2 = "1.0.34"
 insta = { version = "1.39.0", features = ["redactions", "yaml"] }
 which = "6.0.3"
 lets_find_up = "0.0.3"
@@ -40,6 +42,7 @@ luajit-src = "210.5.10"
 target-lexicon = "0.12.16"
 clap = { version = "4.5.3", features = ["derive"], optional = true}
 async-recursion = "1.1.1"
+infer = "0.16.0"
 
 [dev-dependencies]
 httptest = { version = "0.16.1" }

--- a/rocks-lib/src/build/fetch.rs
+++ b/rocks-lib/src/build/fetch.rs
@@ -1,0 +1,24 @@
+use git2::Repository;
+use eyre::Result;
+
+use crate::rockspec::RockSourceSpec;
+
+pub async fn fetch_src(temp_dir: tempdir::TempDir, source_spec: &RockSourceSpec) -> Result<()> {
+    match source_spec {
+        RockSourceSpec::Git(git) => {
+            let repo = Repository::clone(&git.url.to_string(), &temp_dir)?;
+
+            if let Some(commit_hash) = &git.checkout_ref {
+                let (object, _) = repo.revparse_ext(commit_hash)?;
+                repo.checkout_tree(&object, None)?;
+            }
+        }
+        RockSourceSpec::Url(_) => unimplemented!(),
+        RockSourceSpec::File(_) => unimplemented!(),
+        RockSourceSpec::Cvs(_) => unimplemented!(),
+        RockSourceSpec::Mercurial(_) => unimplemented!(),
+        RockSourceSpec::Sscm(_) => unimplemented!(),
+        RockSourceSpec::Svn(_) => unimplemented!(),
+    }
+    Ok(())
+}

--- a/rocks-lib/src/build/fetch.rs
+++ b/rocks-lib/src/build/fetch.rs
@@ -1,19 +1,46 @@
-use git2::Repository;
+use eyre::eyre;
 use eyre::Result;
+use flate2::read::GzDecoder;
+use git2::Repository;
+use std::io::Cursor;
+use std::path::Path;
 
+use crate::rockspec::RockSource;
 use crate::rockspec::RockSourceSpec;
 
-pub async fn fetch_src(temp_dir: tempdir::TempDir, source_spec: &RockSourceSpec) -> Result<()> {
-    match source_spec {
+pub async fn fetch_src(dest_dir: &Path, rock_source: &RockSource) -> Result<()> {
+    match &rock_source.source_spec {
         RockSourceSpec::Git(git) => {
-            let repo = Repository::clone(&git.url.to_string(), &temp_dir)?;
+            let repo = Repository::clone(&git.url.to_string(), dest_dir)?;
 
             if let Some(commit_hash) = &git.checkout_ref {
                 let (object, _) = repo.revparse_ext(commit_hash)?;
                 repo.checkout_tree(&object, None)?;
             }
         }
-        RockSourceSpec::Url(_) => unimplemented!(),
+        RockSourceSpec::Url(url) => {
+            let response = reqwest::get(url.to_owned()).await?.bytes().await?;
+            let cursor = Cursor::new(response);
+            let file_type = infer::get(cursor.get_ref()).unwrap();
+            match file_type.mime_type() {
+                "application/zip" => {
+                    let mut archive = zip::ZipArchive::new(cursor)?;
+                    archive.extract(dest_dir)?;
+                }
+                "application/x-tar" => {
+                    let mut archive = tar::Archive::new(cursor);
+                    archive.unpack(dest_dir)?;
+                }
+                "application/gzip" => {
+                    let tar = GzDecoder::new(cursor);
+                    let mut archive = tar::Archive::new(tar);
+                    archive.unpack(dest_dir)?;
+                }
+                other => {
+                    return Err(eyre!("Rockspec source has unsupported file type {}", other));
+                }
+            }
+        }
         RockSourceSpec::File(_) => unimplemented!(),
         RockSourceSpec::Cvs(_) => unimplemented!(),
         RockSourceSpec::Mercurial(_) => unimplemented!(),

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::Config,
     lua_installation::LuaInstallation,
-    rockspec::{utils, Build as _, BuildBackendSpec, RockSourceSpec, Rockspec},
+    rockspec::{utils, Build as _, BuildBackendSpec, Rockspec},
     tree::{RockLayout, Tree},
 };
 use async_recursion::async_recursion;
@@ -67,7 +67,12 @@ pub async fn build(rockspec: Rockspec, config: &Config) -> Result<()> {
     std::env::set_current_dir(&temp_dir)?;
 
     // Install the source in order to build.
-    fetch::fetch_src(temp_dir, &rockspec.source.current_platform().source_spec).await?;
+    let rock_source = rockspec.source.current_platform();
+    fetch::fetch_src(temp_dir.path(), rock_source).await?;
+
+    if let Some(unpack_dir) = &rock_source.unpack_dir {
+        std::env::set_current_dir(temp_dir.path().join(unpack_dir))?;
+    }
 
     // TODO(vhyrro): Instead of copying bit-by-bit we should instead perform all of these
     // operations in the temporary directory itself and then copy all results over once they've

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -435,7 +435,10 @@ mod tests {
         "
         .to_string();
         let rockspec = Rockspec::new(&rockspec_content).unwrap();
-        assert_eq!(rockspec.source.default.archive_name, "foo.tar.gz");
+        assert_eq!(
+            rockspec.source.default.archive_name,
+            Some("foo.tar.gz".into())
+        );
         let foo_bar_path = rockspec.build.default.install.conf.get("foo.bar").unwrap();
         assert_eq!(*foo_bar_path, PathBuf::from("config/bar.toml"));
         let rockspec_content = "
@@ -454,8 +457,6 @@ mod tests {
         "
         .to_string();
         let rockspec = Rockspec::new(&rockspec_content).unwrap();
-        assert_eq!(rockspec.source.default.archive_name, "foo.zip");
-        assert_eq!(rockspec.source.default.unpack_dir, "foo");
         assert!(matches!(
             rockspec.build.default.build_backend,
             Some(BuildBackendSpec::Builtin { .. })
@@ -543,8 +544,7 @@ mod tests {
         "
         .to_string();
         let rockspec = Rockspec::new(&rockspec_content).unwrap();
-        assert_eq!(rockspec.source.default.archive_name, "foo.zip");
-        assert_eq!(rockspec.source.default.unpack_dir, "baz");
+        assert_eq!(rockspec.source.default.unpack_dir, Some("baz".into()));
         assert_eq!(
             rockspec.build.default.build_backend,
             Some(BuildBackendSpec::Make(MakeBuildSpec::default()))


### PR DESCRIPTION
This adds support for rockspecs with `.zip` or `.tar`/`.tar.gz` archives in their source URLs.

I've tested it manually with haskell-tools.nvim (which has a zip archive in the `source.url`).