### PR TITLE
feat(build): enable parallel compilation

### DIFF
--- a/rocks-lib/Cargo.toml
+++ b/rocks-lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cc = "1.0.98"
+cc = { version = "1.0.98", features = ["parallel"] }
 directories = "5.0.1"
 eyre = "0.6.12"
 git-url-parse = "0.4.4"


### PR DESCRIPTION
The `cc` crate has a `parallel` feature that enables parallel compilation.