### PR TITLE
fix(version): trim specrev when parsing

### DIFF
--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -509,19 +509,6 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
-        }\n
-        build = {\n
-            copy_directories = { 'foo-1.0.0-1.rockspec' },\n
-        }\n
-        "
-        .to_string();
-        let _rockspec = Rockspec::new(&rockspec_content).unwrap_err();
-        let rockspec_content = "
-        rockspec_format = '1.0'\n
-        package = 'foo'\n
-        version = '1.0.0-1'\n
-        source = {\n
             url = 'git://hub.com/example-project/foo.zip',\n
             dir = 'baz',\n
         }\n
@@ -881,5 +868,20 @@ mod tests {
                 .collect()
             }))
         );
+    }
+
+    #[tokio::test]
+    pub async fn parse_scm_rockspec() {
+        let rockspec_content = "
+        package = 'foo'\n
+        version = 'scm-1'\n
+        source = {\n
+            url = 'https://github.com/nvim-neorocks/rocks.nvim/archive/1.0.0/rocks.nvim.zip',\n
+        }\n
+        "
+        .to_string();
+        let rockspec = Rockspec::new(&rockspec_content).unwrap();
+        assert_eq!(rockspec.package, "foo".into());
+        assert_eq!(rockspec.version, "scm-1".parse().unwrap());
     }
 }

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -109,28 +109,28 @@ mod tests {
         let tree = Tree::new(tree_path.clone(), LuaVersion::Lua51).unwrap();
 
         let neorg = tree
-            .rock(&"neorg".into(), &"8.0.0-1".parse().unwrap())
+            .rock(&"neorg".into(), &"8.0.0".parse().unwrap())
             .unwrap();
 
         assert_eq!(
             neorg,
             RockLayout {
-                etc: tree_path.join("5.1/neorg@8.0.0-1/etc"),
-                lib: tree_path.join("5.1/neorg@8.0.0-1/lib"),
-                src: tree_path.join("5.1/neorg@8.0.0-1/src"),
+                etc: tree_path.join("5.1/neorg@8.0.0/etc"),
+                lib: tree_path.join("5.1/neorg@8.0.0/lib"),
+                src: tree_path.join("5.1/neorg@8.0.0/src"),
             }
         );
 
         let lua_cjson = tree
-            .rock(&"lua-cjson".into(), &"2.1.0-1".parse().unwrap())
+            .rock(&"lua-cjson".into(), &"2.1.0".parse().unwrap())
             .unwrap();
 
         assert_eq!(
             lua_cjson,
             RockLayout {
-                etc: tree_path.join("5.1/lua-cjson@2.1.0-1/etc"),
-                lib: tree_path.join("5.1/lua-cjson@2.1.0-1/lib"),
-                src: tree_path.join("5.1/lua-cjson@2.1.0-1/src"),
+                etc: tree_path.join("5.1/lua-cjson@2.1.0/etc"),
+                lib: tree_path.join("5.1/lua-cjson@2.1.0/lib"),
+                src: tree_path.join("5.1/lua-cjson@2.1.0/src"),
             }
         );
     }

--- a/rocks-lib/src/tree/snapshots/rocks_lib__tree__tests__tree_list.snap
+++ b/rocks-lib/src/tree/snapshots/rocks_lib__tree__tests__tree_list.snap
@@ -4,6 +4,6 @@ assertion_line: 141
 expression: tree.list()
 ---
 lua-cjson:
-  - 2.1.0-1
+  - 2.1.0
 neorg:
-  - 8.0.0-1
+  - 8.0.0


### PR DESCRIPTION
specrev is likely to lead to all sorts of issues.
Let's not support it (at least for now).