### PR TITLE
feat: add `rocks info` command

### DIFF
--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -2,7 +2,10 @@ use clap::Args;
 use eyre::Result;
 use indicatif::MultiProgress;
 use rocks_lib::{
-    config::{Config, LuaVersion}, operations::download_rockspec, package::PackageReq, tree::Tree
+    config::{Config, LuaVersion},
+    operations::download_rockspec,
+    package::PackageReq,
+    tree::Tree,
 };
 
 #[derive(Args)]
@@ -24,10 +27,32 @@ pub async fn info(data: Info, config: Config) -> Result<()> {
     println!("Package version: {}", rockspec.version);
     println!();
 
-    println!("Summary: {}", rockspec.description.summary.unwrap_or("None".into()));
-    println!("Description: {}", rockspec.description.detailed.unwrap_or("None".into()));
-    println!("License: {}", rockspec.description.license.unwrap_or("None (all rights reserved by the author)".into()));
-    println!("Maintainer: {}", rockspec.description.maintainer.unwrap_or("Unspecified".into()));
+    println!(
+        "Summary: {}",
+        rockspec.description.summary.unwrap_or("None".into())
+    );
+    println!(
+        "Description: {}",
+        rockspec
+            .description
+            .detailed
+            .unwrap_or("None".into())
+            .trim()
+    );
+    println!(
+        "License: {}",
+        rockspec
+            .description
+            .license
+            .unwrap_or("Unknown (all rights reserved by the author)".into())
+    );
+    println!(
+        "Maintainer: {}",
+        rockspec
+            .description
+            .maintainer
+            .unwrap_or("Unspecified".into())
+    );
 
     Ok(())
 }

--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -1,0 +1,33 @@
+use clap::Args;
+use eyre::Result;
+use indicatif::MultiProgress;
+use rocks_lib::{
+    config::{Config, LuaVersion}, operations::download_rockspec, package::PackageReq, tree::Tree
+};
+
+#[derive(Args)]
+pub struct Info {
+    package: PackageReq,
+}
+
+pub async fn info(data: Info, config: Config) -> Result<()> {
+    // TODO(vhyrro): Add `Tree::from(&Config)`
+    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+
+    let rockspec = download_rockspec(&MultiProgress::new(), &data.package, &config).await?;
+
+    if tree.has_rock(&data.package).is_some() {
+        println!("Currently installed in {}", tree.root().display());
+    }
+
+    println!("Package name: {}", rockspec.package);
+    println!("Package version: {}", rockspec.version);
+    println!();
+
+    println!("Summary: {}", rockspec.description.summary.unwrap_or("None".into()));
+    println!("Description: {}", rockspec.description.detailed.unwrap_or("None".into()));
+    println!("License: {}", rockspec.description.license.unwrap_or("None (all rights reserved by the author)".into()));
+    println!("Maintainer: {}", rockspec.description.maintainer.unwrap_or("Unspecified".into()));
+
+    Ok(())
+}

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -5,6 +5,7 @@ use build::Build;
 use clap::{Parser, Subcommand};
 use debug::Debug;
 use download::Download;
+use info::Info;
 use install::Install;
 use list::ListCmd;
 use outdated::Outdated;
@@ -18,6 +19,7 @@ mod debug;
 mod download;
 mod fetch;
 mod format;
+mod info;
 mod install;
 mod install_lua;
 mod list;
@@ -108,6 +110,8 @@ enum Commands {
     Download(Download),
     /// Formats the codebase with stylua.
     Fmt,
+    /// Show information about an installed rock.
+    Info(Info),
     /// Install a rock for use on the system.
     #[command(arg_required_else_help = true)]
     Install(Install),
@@ -132,8 +136,6 @@ enum Commands {
     /// Query the Luarocks servers.
     #[command(arg_required_else_help = true)]
     Search(Search),
-    /// Show information about an installed rock.
-    Show,
     /// Run the test suite in the current directory.
     Test,
     /// Uninstall a rock from the system.
@@ -194,6 +196,7 @@ async fn main() {
         Commands::Purge => purge::purge(config).await.unwrap(),
         Commands::Remove(remove_args) => remove::remove(remove_args, config).await.unwrap(),
         Commands::Update(_update_args) => update::update(config).await.unwrap(),
+        Commands::Info(info_data) => info::info(info_data, config).await.unwrap(),
         _ => unimplemented!(),
     }
 }


### PR DESCRIPTION
This feature is so uninspiring that I stopped working on it halfway, thus it's a draft :smile: 

I'd like to first implement `rocks doc` and have a general interface for grabbing documentation, so that it can be showed to the user when invoking `rocks info`.

I renamed `rocks show` to `rocks info` because `show` has always felt incredibly unintuitive to me. We may even want to make `rocks info` work for any rock, both remote and local, and display whether it's installed or not in the output.