### PR TITLE
refactor(config)!: allow customizable cache and data directories

### DIFF
--- a/rocks-bin/src/format.rs
+++ b/rocks-bin/src/format.rs
@@ -39,5 +39,18 @@ pub fn format() -> Result<()> {
             Ok::<_, eyre::Report>(())
         })?;
 
+    // Format the rockspec
+
+    let rockspec = project.root().join("project.rockspec");
+
+    let formatted_code = stylua_lib::format_code(
+        &std::fs::read_to_string(&rockspec)?,
+        config,
+        None,
+        stylua_lib::OutputVerification::Full,
+    )?;
+
+    std::fs::write(rockspec, formatted_code)?;
+
     Ok(())
 }

--- a/rocks-lib/src/manifest/pull_manifest.rs
+++ b/rocks-lib/src/manifest/pull_manifest.rs
@@ -15,7 +15,7 @@ pub async fn manifest_from_server(url: String, config: &Config) -> Result<String
 
     // Stores a path to the manifest cache (this allows us to operate on a manifest without
     // needing to pull it from the luarocks servers each time).
-    let cache = Config::get_default_cache_path()?.join(&manifest_filename);
+    let cache = config.cache_dir().join(&manifest_filename);
 
     // Ensure all intermediate directories for the cache file are created (e.g. `~/.cache/rocks/manifest`)
     fs::create_dir_all(cache.parent().unwrap())?;
@@ -65,12 +65,6 @@ mod tests {
 
     use super::*;
 
-    fn reset_cache() {
-        let cache_path = Config::get_default_cache_path().unwrap();
-        let _ = fs::remove_dir_all(&cache_path);
-        fs::create_dir_all(cache_path).unwrap();
-    }
-
     fn start_test_server(manifest_name: String) -> Server {
         let server = Server::run();
         let manifest_path = format!("/{}", manifest_name);
@@ -89,23 +83,27 @@ mod tests {
     #[tokio::test]
     #[serial]
     pub async fn get_manifest() {
-        reset_cache();
+        let cache_dir = assert_fs::TempDir::new().unwrap().to_path_buf();
         let server = start_test_server("manifest".into());
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
-        let config = ConfigBuilder::new().build().unwrap();
+        let config = ConfigBuilder::new()
+            .cache_dir(Some(cache_dir))
+            .build()
+            .unwrap();
         manifest_from_server(url_str, &config).await.unwrap();
     }
 
     #[tokio::test]
     #[serial]
     pub async fn get_manifest_for_5_1() {
-        reset_cache();
+        let cache_dir = assert_fs::TempDir::new().unwrap().to_path_buf();
         let server = start_test_server("manifest-5.1".into());
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
 
         let config = ConfigBuilder::new()
+            .cache_dir(Some(cache_dir))
             .lua_version(Some(crate::config::LuaVersion::Lua51))
             .build()
             .unwrap();
@@ -116,16 +114,18 @@ mod tests {
     #[tokio::test]
     #[serial]
     pub async fn get_cached_manifest() {
-        reset_cache();
         let server = start_test_server("manifest".into());
         let mut url_str = server.url_str(""); // Remove trailing "/"
         url_str.pop();
         let manifest_content = "dummy data";
-        let config = ConfigBuilder::new().build().unwrap();
-        let cache_dir = Config::get_default_cache_path().unwrap();
+        let cache_dir = assert_fs::TempDir::new().unwrap();
         let cache = cache_dir.join("manifest");
         fs::write(&cache, manifest_content).unwrap();
         let _metadata = fs::metadata(&cache).unwrap();
+        let config = ConfigBuilder::new()
+            .cache_dir(Some(cache_dir.to_path_buf()))
+            .build()
+            .unwrap();
         let result = manifest_from_server(url_str, &config).await.unwrap();
         assert_eq!(result, manifest_content);
     }


### PR DESCRIPTION
This opens the door for customizable cache directories from the CLI, but is also important to (finally) properly isolate the manifest tests.