### PR TITLE
fix: properly unpack tar archives

### DIFF
--- a/rocks-lib/src/operations/fetch.rs
+++ b/rocks-lib/src/operations/fetch.rs
@@ -4,7 +4,9 @@ use flate2::read::GzDecoder;
 use git2::build::RepoBuilder;
 use git2::FetchOptions;
 use indicatif::MultiProgress;
+use itertools::Itertools;
 use std::fs::File;
+use std::io::BufReader;
 use std::io::Cursor;
 use std::io::Read;
 use std::io::Seek;
@@ -60,7 +62,15 @@ pub async fn fetch_src(
                 .unwrap_or(url.to_string());
             let cursor = Cursor::new(response);
             let mime_type = infer::get(cursor.get_ref()).map(|file_type| file_type.mime_type());
-            unpack(progress, mime_type, cursor, file_name, dest_dir).await?
+            unpack(
+                progress,
+                mime_type,
+                cursor,
+                rock_source.unpack_dir.is_none(),
+                file_name,
+                dest_dir,
+            )
+            .await?
         }
         RockSourceSpec::File(path) => {
             if path.is_dir() {
@@ -92,7 +102,15 @@ pub async fn fetch_src(
                     .map(|os_str| os_str.to_string_lossy())
                     .unwrap_or(path.to_string_lossy())
                     .to_string();
-                unpack(progress, mime_type, file, file_name, dest_dir).await?
+                unpack(
+                    progress,
+                    mime_type,
+                    file,
+                    rock_source.unpack_dir.is_none(),
+                    file_name,
+                    dest_dir,
+                )
+                .await?
             }
         }
         RockSourceSpec::Cvs(_) => unimplemented!(),
@@ -112,14 +130,56 @@ pub async fn fetch_src_rock(
     let src_rock = operations::download_src_rock(progress, package, config).await?;
     let cursor = Cursor::new(src_rock.bytes);
     let mime_type = infer::get(cursor.get_ref()).map(|file_type| file_type.mime_type());
-    unpack(progress, mime_type, cursor, src_rock.file_name, dest_dir).await?;
+    unpack(
+        progress,
+        mime_type,
+        cursor,
+        false,
+        src_rock.file_name,
+        dest_dir,
+    )
+    .await?;
     Ok(())
+}
+
+fn is_single_directory<R: Read + Seek + Send>(reader: R) -> Result<bool> {
+    let tar = GzDecoder::new(reader);
+    let mut archive = tar::Archive::new(tar);
+
+    let entries: Vec<_> = archive
+        .entries()?
+        .filter_map(|entry| {
+            if entry.as_ref().ok()?.path().ok()?.file_name()? != "pax_global_header" {
+                Some(entry)
+            } else {
+                None
+            }
+        })
+        .try_collect()?;
+
+    let directory: PathBuf = entries
+        .first()
+        .unwrap()
+        .path()?
+        .components()
+        .take(1)
+        .collect();
+
+    Ok(entries.into_iter().all(|entry| {
+        entry
+            .path()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with(directory.to_str().unwrap())
+    }))
 }
 
 async fn unpack<R: Read + Seek + Send>(
     progress: &MultiProgress,
     mime_type: Option<&str>,
     reader: R,
+    auto_find_lua_sources: bool,
     file_name: String,
     dest_dir: &Path,
 ) -> Result<()> {
@@ -134,19 +194,33 @@ async fn unpack<R: Read + Seek + Send>(
                 archive.unpack(dest_dir)?;
             }
             Some("application/gzip") => {
-                let tar = GzDecoder::new(reader);
+                let mut bufreader = BufReader::new(reader);
+
+                let extract_subdirectory =
+                    auto_find_lua_sources && is_single_directory(&mut bufreader)?;
+
+                bufreader.rewind()?;
+                let tar = GzDecoder::new(bufreader);
                 let mut archive = tar::Archive::new(tar);
 
-                if archive.entries()?.count() == 1 {
+                if extract_subdirectory {
                     archive.entries()?.try_for_each(|entry| {
                         let mut entry = entry?;
-                        entry.unpack(
-                            dest_dir.join(entry.path()?.components().skip(1).collect::<PathBuf>()),
-                        )?;
+
+                        let path: PathBuf = entry.path()?.components().skip(1).collect();
+                        if path.components().count() > 0 {
+                            let dest = dest_dir.join(path);
+                            std::fs::create_dir_all(dest.parent().unwrap())?;
+                            entry.unpack(dest)?;
+                        }
+
                         Ok::<_, eyre::Report>(())
                     })?;
                 } else {
-                    archive.unpack(dest_dir)?;
+                    archive.entries()?.try_for_each(|entry| {
+                        entry?.unpack_in(dest_dir)?;
+                        Ok::<_, eyre::Report>(())
+                    })?;
                 }
             }
             Some(other) => {

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -323,7 +323,7 @@ mod tests {
         external_dependencies = { FOO = { header = 'foo.h' } }\n
         test_dependencies = { 'busted >= 2.0.0' }\n
         source = {\n
-            url = 'git://github.com/nvim-neorocks/rocks.nvim',\n
+            url = 'git+https://github.com/nvim-neorocks/rocks.nvim',\n
             hash = 'sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=',\n
         }\n
         "
@@ -376,7 +376,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
             branch = 'bar',\n
         }\n
         "
@@ -385,7 +385,7 @@ mod tests {
         assert_eq!(
             rockspec.source.default.source_spec,
             RockSourceSpec::Git(GitSource {
-                url: "git://hub.com/example-project/".parse().unwrap(),
+                url: "https://hub.com/example-project/".parse().unwrap(),
                 checkout_ref: Some("bar".into())
             })
         );
@@ -395,7 +395,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
             tag = 'bar',\n
         }\n
         "
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(
             rockspec.source.default.source_spec,
             RockSourceSpec::Git(GitSource {
-                url: "git://hub.com/example-project/".parse().unwrap(),
+                url: "https://hub.com/example-project/".parse().unwrap(),
                 checkout_ref: Some("bar".into())
             })
         );
@@ -413,7 +413,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
             branch = 'bar',\n
             tag = 'baz',\n
         }\n
@@ -425,7 +425,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
             module = 'bar',\n
         }\n
         "
@@ -436,7 +436,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
             tag = 'bar',\n
             file = 'foo.tar.gz',\n
         }\n
@@ -459,7 +459,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/foo.zip',\n
+            url = 'git+https://hub.com/example-project/foo.zip',\n
         }\n
         build = {\n
             install = {\n
@@ -483,7 +483,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
         }\n
         build = {\n
             copy_directories = { 'lua' },\n
@@ -496,7 +496,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
         }\n
         build = {\n
             copy_directories = { 'lib' },\n
@@ -509,7 +509,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/',\n
+            url = 'git+https://hub.com/example-project/',\n
         }\n
         build = {\n
             copy_directories = { 'rock_manifest' },\n
@@ -522,7 +522,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/foo.zip',\n
+            url = 'git+https://hub.com/example-project/foo.zip',\n
             dir = 'baz',\n
         }\n
         build = {\n
@@ -563,7 +563,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/foo.zip',\n
+            url = 'git+https://hub.com/example-project/foo.zip',\n
         }\n
         build = {\n
             type = 'cmake',\n
@@ -580,7 +580,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/foo.zip',\n
+            url = 'git+https://hub.com/example-project/foo.zip',\n
         }\n
         build = {\n
             type = 'command',\n
@@ -599,7 +599,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/foo.zip',\n
+            url = 'git+https://hub.com/example-project/foo.zip',\n
         }\n
         build = {\n
             type = 'command',\n
@@ -613,7 +613,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/foo.zip',\n
+            url = 'git+https://hub.com/example-project/foo.zip',\n
         }\n
         build = {\n
             type = 'command',\n
@@ -643,7 +643,7 @@ mod tests {
           },\n
         }\n
         source = {\n
-            url = 'git://github.com/nvim-neorocks/rocks.nvim',\n
+            url = 'git+https://github.com/nvim-neorocks/rocks.nvim',\n
             hash = 'sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=',\n
         }\n
         "
@@ -755,7 +755,7 @@ mod tests {
         package = 'foo'\n
         version = '1.0.0-1'\n
         source = {\n
-            url = 'git://hub.com/example-project/.git',\n
+            url = 'git+https://hub.com/example-project/.git',\n
             branch = 'bar',\n
             platforms = {\n
                 macosx = {\n
@@ -773,7 +773,7 @@ mod tests {
         assert_eq!(
             rockspec.source.default.source_spec,
             RockSourceSpec::Git(GitSource {
-                url: "git://hub.com/example-project/.git".parse().unwrap(),
+                url: "https://hub.com/example-project/.git".parse().unwrap(),
                 checkout_ref: Some("bar".into())
             })
         );
@@ -785,7 +785,7 @@ mod tests {
                 .map(|it| it.source_spec.clone())
                 .unwrap(),
             RockSourceSpec::Git(GitSource {
-                url: "git://hub.com/example-project/.git".parse().unwrap(),
+                url: "https://hub.com/example-project/.git".parse().unwrap(),
                 checkout_ref: Some("mac".into())
             })
         );
@@ -805,7 +805,7 @@ mod tests {
         rockspec_format = '1.0'\n
         package = 'foo'\n
         version = '1.0.0-1'\n
-        source = { url = 'git://hub.com/example-project/foo.zip' }\n
+        source = { url = 'git+https://hub.com/example-project/foo.zip' }\n
         build = {\n
             type = 'make',\n
             install = {\n
@@ -842,7 +842,7 @@ mod tests {
         let rockspec_content = "
         package = 'foo'\n
         version = '1.0.0-1'\n
-        source = { url = 'git://hub.com/example-project/foo.zip' }\n
+        source = { url = 'git+https://hub.com/example-project/foo.zip' }\n
         build = {\n
             type = 'builtin',\n
             modules = {\n

--- a/rocks-lib/src/rockspec/rock_source.rs
+++ b/rocks-lib/src/rockspec/rock_source.rs
@@ -228,7 +228,7 @@ impl FromStr for SourceUrl {
                 let path = fs::canonicalize(&path_buf)?;
                 Ok(Self::File(path))
             }
-            s if s.starts_with("git://") => Ok(Self::Git(s.parse()?)),
+            s if s.starts_with("git://") => Ok(Self::Git(s.replacen("git", "https", 1).parse()?)),
             s if starts_with_any(
                 s,
                 ["git+file://", "git+http://", "git+https://", "git+ssh://"].into(),


### PR DESCRIPTION
This PR fixes the installations of `dkjson`, which doesn't specify a `dir` name, even though it theoretically should.

This is fixed by implementing luarocks's "smart" search in tar files, which just involves checking if the unpacked contents of the tar is a single directory and recursively unpacking the directory instead.