### PR TITLE
fix(build/builtin): platform overrides + modules compilation

### DIFF
--- a/rocks-lib/src/build/builtin.rs
+++ b/rocks-lib/src/build/builtin.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     config::Config,
     lua_installation::LuaInstallation,
-    rockspec::{utils, Build, BuiltinBuildSpec, ModuleSpec},
+    rockspec::{utils, Build, BuiltinBuildSpec, LuaModule, ModuleSpec},
     tree::RockLayout,
 };
 use indicatif::{MultiProgress, ProgressBar};
@@ -92,7 +92,7 @@ impl Build for BuiltinBuildSpec {
     }
 }
 
-fn autodetect_modules(build_dir: &Path) -> HashMap<String, ModuleSpec> {
+fn autodetect_modules(build_dir: &Path) -> HashMap<LuaModule, ModuleSpec> {
     WalkDir::new(build_dir.join("src"))
         .into_iter()
         .chain(WalkDir::new(build_dir.join("lua")))
@@ -124,15 +124,10 @@ fn autodetect_modules(build_dir: &Path) -> HashMap<String, ModuleSpec> {
             // The rockspec requires the format to be like this, and representing our
             // data in this form allows us to respect any overrides made by the user (which follow
             // the `module.name` format, not our internal one).
-            let lua_module_path = diff
-                .components()
-                .skip(1)
-                .collect::<PathBuf>()
-                .to_string_lossy()
-                .trim_end_matches(".lua")
-                .replace(std::path::MAIN_SEPARATOR_STR, ".");
+            let pathbuf = diff.components().skip(1).collect::<PathBuf>();
+            let lua_module = LuaModule::from_pathbuf(pathbuf);
 
-            (lua_module_path, ModuleSpec::SourcePath(diff))
+            (lua_module, ModuleSpec::SourcePath(diff))
         })
         .collect()
 }

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -63,7 +63,7 @@ async fn run_build(
     build_dir: &Path,
 ) -> Result<(), BuildError> {
     with_spinner(progress, "🛠️ Building...".into(), || async {
-        match rockspec.build.default.build_backend.to_owned() {
+        match rockspec.build.current_platform().build_backend.to_owned() {
             Some(BuildBackendSpec::Builtin(build_spec)) => {
                 build_spec
                     .run(progress, output_paths, false, lua, config, build_dir)

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -533,7 +533,13 @@ mod tests {
             rockspec.build.default.build_backend,
             Some(BuildBackendSpec::Builtin { .. })
         ));
-        let foo_bar_path = rockspec.build.default.install.lua.get("foo.bar").unwrap();
+        let foo_bar_path = rockspec
+            .build
+            .default
+            .install
+            .lua
+            .get(&LuaModule::from_str("foo.bar").unwrap())
+            .unwrap();
         assert_eq!(*foo_bar_path, PathBuf::from("src/bar.lua"));
         let foo_bar_path = rockspec.build.default.install.bin.get("foo.bar").unwrap();
         assert_eq!(*foo_bar_path, PathBuf::from("bin/bar"));
@@ -608,7 +614,13 @@ mod tests {
             rockspec.build.default.build_backend,
             Some(BuildBackendSpec::Make(MakeBuildSpec::default()))
         );
-        let foo_bar_path = rockspec.build.default.install.lib.get("foo.bar").unwrap();
+        let foo_bar_path = rockspec
+            .build
+            .default
+            .install
+            .lib
+            .get(&LuaModule::from_str("foo.bar").unwrap())
+            .unwrap();
         assert_eq!(*foo_bar_path, PathBuf::from("lib/bar.so"));
         let copy_directories = rockspec.build.default.copy_directories;
         assert_eq!(
@@ -924,7 +936,7 @@ mod tests {
             win32.build_backend,
             Some(BuildBackendSpec::Builtin(BuiltinBuildSpec {
                 modules: vec![(
-                    "cjson".into(),
+                    LuaModule::from_str("cjson").unwrap(),
                     ModuleSpec::ModulePaths(ModulePaths {
                         sources: vec!["lua_cjson.c".into(), "strbuf.c".into(), "fpconv.c".into()],
                         libraries: Vec::default(),
@@ -1058,11 +1070,11 @@ build = {
             &build_spec.build_backend
         {
             assert_eq!(
-                modules.get("system.init"),
+                modules.get(&LuaModule::from_str("system.init").unwrap()),
                 Some(&ModuleSpec::SourcePath("system/init.lua".into()))
             );
             assert_eq!(
-                modules.get("system.core"),
+                modules.get(&LuaModule::from_str("system.core").unwrap()),
                 Some(&ModuleSpec::ModulePaths(ModulePaths {
                     sources: vec![
                         "src/core.c".into(),


### PR DESCRIPTION
Fixes #190.

- [x] Use `.current_platform()` for builtin build spec.
- [x] Compile intermediates in a temp directory so they don't clutter the install tree.
- [x] Apply fix for #182 to `ModulesSpec` compilation step.
- [x] Introduce `LuaModule` newtype wrapper. 