### PR TITLE
refactor: move away from `indicatif::MultiProgress`

### DIFF
--- a/rocks-bin/src/download.rs
+++ b/rocks-bin/src/download.rs
@@ -1,7 +1,6 @@
 use clap::Args;
 use eyre::Result;
-use indicatif::MultiProgress;
-use rocks_lib::{config::Config, package::PackageReq};
+use rocks_lib::{config::Config, package::PackageReq, progress::MultiProgress};
 
 #[derive(Args)]
 pub struct Download {
@@ -9,17 +8,16 @@ pub struct Download {
 }
 
 pub async fn download(dl_data: Download, config: Config) -> Result<()> {
-    println!("Downloading {}...", dl_data.package_req.name());
+    let progress = MultiProgress::new();
+    let bar = progress.new_bar();
 
-    let rock = rocks_lib::operations::download_to_file(
-        &MultiProgress::new(),
-        &dl_data.package_req,
-        None,
-        &config,
-    )
-    .await?;
+    let rock =
+        rocks_lib::operations::download_to_file(&bar, &dl_data.package_req, None, &config).await?;
 
-    println!("Succesfully downloaded {}@{}", rock.name, rock.version);
+    bar.finish_with_message(format!(
+        "Succesfully downloaded {}@{}",
+        rock.name, rock.version
+    ));
 
     Ok(())
 }

--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -1,10 +1,10 @@
 use clap::Args;
 use eyre::Result;
-use indicatif::MultiProgress;
 use rocks_lib::{
     config::{Config, LuaVersion},
     operations::download_rockspec,
     package::PackageReq,
+    progress::MultiProgress,
     tree::Tree,
 };
 
@@ -17,7 +17,12 @@ pub async fn info(data: Info, config: Config) -> Result<()> {
     // TODO(vhyrro): Add `Tree::from(&Config)`
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
 
-    let rockspec = download_rockspec(&MultiProgress::new(), &data.package, &config).await?;
+    let progress = MultiProgress::new();
+    let bar = progress.new_bar();
+
+    let rockspec = download_rockspec(&bar, &data.package, &config).await?;
+
+    bar.finish_and_clear();
 
     if tree.has_rock(&data.package).is_some() {
         println!("Currently installed in {}", tree.root().display());

--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -1,5 +1,4 @@
 use eyre::Result;
-use indicatif::MultiProgress;
 use inquire::Confirm;
 use itertools::Itertools;
 use rocks_lib::{
@@ -7,6 +6,7 @@ use rocks_lib::{
     config::{Config, LuaVersion},
     lockfile::PinnedState,
     package::PackageReq,
+    progress::MultiProgress,
     tree::Tree,
 };
 

--- a/rocks-bin/src/install_lua.rs
+++ b/rocks-bin/src/install_lua.rs
@@ -1,27 +1,22 @@
-use std::convert::Infallible;
-
 use eyre::Result;
-use indicatif::MultiProgress;
 use rocks_lib::{
     config::{Config, LuaVersion},
     lua_installation::LuaInstallation,
-    progress::with_spinner,
+    progress::{MultiProgress, ProgressBar},
 };
 
 pub async fn install_lua(config: Config) -> Result<()> {
     let version_stringified = &LuaVersion::from(&config)?;
 
-    with_spinner(
-        &MultiProgress::new(),
-        format!("🌔 Installing Lua {}", version_stringified),
-        || async {
-            // TODO: Detect when path already exists by checking `Lua::path()` and prompt the user
-            // whether they'd like to forcefully reinstall.
-            LuaInstallation::new(version_stringified, &config);
-            Ok::<_, Infallible>(())
-        },
-    )
-    .await?;
+    let progress = MultiProgress::new();
+    progress.add(ProgressBar::from(format!(
+        "🌔 Installing Lua {}",
+        version_stringified
+    )));
+
+    // TODO: Detect when path already exists by checking `Lua::path()` and prompt the user
+    // whether they'd like to forcefully reinstall.
+    LuaInstallation::new(version_stringified, &config);
 
     Ok(())
 }

--- a/rocks-bin/src/purge.rs
+++ b/rocks-bin/src/purge.rs
@@ -1,11 +1,8 @@
-use std::io;
-
 use eyre::Result;
-use indicatif::MultiProgress;
 use inquire::Confirm;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    progress::with_spinner,
+    progress::{MultiProgress, ProgressBar},
     tree::Tree,
 };
 
@@ -19,15 +16,12 @@ pub async fn purge(config: Config) -> Result<()> {
         .prompt()?
     {
         let root_dir = tree.root();
-        with_spinner(
-            &MultiProgress::new(),
-            format!("🗑️ Purging {}", root_dir.display()),
-            || async {
-                std::fs::remove_dir_all(tree.root())?;
-                Ok::<_, io::Error>(())
-            },
-        )
-        .await?
+
+        let _spinner = MultiProgress::new().add(ProgressBar::from(format!(
+            "🗑️ Purging {}",
+            root_dir.display()
+        )));
+        std::fs::remove_dir_all(tree.root())?;
     }
 
     Ok(())

--- a/rocks-bin/src/remove.rs
+++ b/rocks-bin/src/remove.rs
@@ -1,10 +1,10 @@
 use clap::Args;
 use eyre::Result;
-use indicatif::MultiProgress;
 use rocks_lib::{
     config::{Config, LuaVersion},
     manifest::{manifest_from_server, ManifestMetadata},
     package::{PackageName, PackageVersion, RemotePackage},
+    progress::MultiProgress,
     tree::Tree,
 };
 
@@ -32,7 +32,10 @@ pub async fn remove(remove_args: Remove, config: Config) -> Result<()> {
         &RemotePackage::new(remove_args.name.clone(), target_version.clone()).into_package_req(),
     ) {
         Some(package) => {
-            Ok(rocks_lib::operations::remove(&MultiProgress::new(), package, &config).await?)
+            Ok(
+                rocks_lib::operations::remove(&MultiProgress::new().new_bar(), package, &config)
+                    .await?,
+            )
         }
         None => {
             eprintln!("Could not find {}@{}", remove_args.name, target_version);

--- a/rocks-bin/src/search.rs
+++ b/rocks-bin/src/search.rs
@@ -9,6 +9,7 @@ use rocks_lib::{
     config::Config,
     manifest::{manifest_from_server, ManifestMetadata},
     package::{PackageName, PackageReq, PackageVersion},
+    progress::{MultiProgress, ProgressBar},
 };
 
 #[derive(Args)]
@@ -21,6 +22,12 @@ pub struct Search {
 }
 
 pub async fn search(data: Search, config: Config) -> Result<()> {
+    let progress = MultiProgress::new();
+    let bar = progress.add(ProgressBar::from(format!(
+        "🔎 Searching for `{}`...",
+        data.lua_package_req
+    )));
+
     let formatting = TreeFormatting::dir_tree(FormatCharacters::box_chars());
 
     let manifest = manifest_from_server(config.server().clone(), &config).await?;
@@ -50,6 +57,8 @@ pub async fn search(data: Search, config: Config) -> Result<()> {
             }
         })
         .collect();
+
+    bar.finish_and_clear();
 
     if data.porcelain {
         println!("{}", serde_json::to_string(&rock_to_version_map)?);

--- a/rocks-bin/src/test.rs
+++ b/rocks-bin/src/test.rs
@@ -1,9 +1,9 @@
 use clap::Args;
 use eyre::{OptionExt, Result};
-use indicatif::MultiProgress;
 use rocks_lib::{
     config::Config,
     operations::{ensure_busted, ensure_dependencies, run_tests, TestEnv},
+    progress::MultiProgress,
     project::Project,
     tree::Tree,
 };

--- a/rocks-bin/src/update.rs
+++ b/rocks-bin/src/update.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 use eyre::Result;
-use indicatif::MultiProgress;
 use rocks_lib::config::LuaVersion;
 use rocks_lib::lockfile::PinnedState;
+use rocks_lib::progress::{MultiProgress, ProgressBar};
 use rocks_lib::{
     config::Config,
     manifest::{manifest_from_server, ManifestMetadata},
@@ -15,14 +15,15 @@ use rocks_lib::{
 pub struct Update {}
 
 pub async fn update(config: Config) -> Result<()> {
+    let progress = MultiProgress::new();
+    progress.add(ProgressBar::from("🔎 Looking for updates...".to_string()));
+
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
 
     let lockfile = tree.lockfile()?;
     let rocks = lockfile.rocks();
     let manifest =
         ManifestMetadata::new(&manifest_from_server(config.server().clone(), &config).await?)?;
-
-    let progress = MultiProgress::new();
 
     for package in rocks.values() {
         if package.pinned == PinnedState::Unpinned {

--- a/rocks-lib/src/build/make.rs
+++ b/rocks-lib/src/build/make.rs
@@ -1,4 +1,3 @@
-use indicatif::MultiProgress;
 use itertools::Itertools;
 use std::{
     io,
@@ -11,6 +10,7 @@ use crate::{
     build::variables::HasVariables,
     config::Config,
     lua_installation::LuaInstallation,
+    progress::ProgressBar,
     rockspec::{Build, MakeBuildSpec},
     tree::RockLayout,
 };
@@ -36,7 +36,7 @@ impl Build for MakeBuildSpec {
 
     async fn run(
         self,
-        _progress: &MultiProgress,
+        _progress: &ProgressBar,
         output_paths: &RockLayout,
         no_install: bool,
         lua: &LuaInstallation,

--- a/rocks-lib/src/lockfile/mod.rs
+++ b/rocks-lib/src/lockfile/mod.rs
@@ -2,12 +2,14 @@ use std::io::{self, Write};
 use std::{collections::HashMap, fs::File, io::ErrorKind, path::PathBuf};
 
 use itertools::Itertools;
-use mlua::ExternalResult;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use ssri::Integrity;
 
 use crate::package::{PackageName, PackageReq, PackageVersion, PackageVersionReq, RemotePackage};
+
+#[cfg(feature = "lua")]
+use mlua::ExternalResult as _;
 
 #[derive(Copy, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub enum PinnedState {

--- a/rocks-lib/src/operations/remove.rs
+++ b/rocks-lib/src/operations/remove.rs
@@ -2,8 +2,8 @@ use std::io;
 
 use crate::config::{LuaVersion, LuaVersionUnset};
 use crate::lockfile::LocalPackage;
-use crate::{config::Config, progress::with_spinner, tree::Tree};
-use indicatif::MultiProgress;
+use crate::progress::ProgressBar;
+use crate::{config::Config, tree::Tree};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -15,16 +15,13 @@ pub enum RemoveError {
 
 // TODO: Remove dependencies recursively too!
 pub async fn remove(
-    progress: &MultiProgress,
+    progress: &ProgressBar,
     package: LocalPackage,
     config: &Config,
 ) -> Result<(), RemoveError> {
-    with_spinner(
-        progress,
-        format!("🗑️ Removing {}@{}", package.name, package.version),
-        || async { remove_impl(package, config).await },
-    )
-    .await
+    progress.set_message(format!("🗑️ Removing {}@{}", package.name, package.version));
+
+    remove_impl(package, config).await
 }
 
 async fn remove_impl(package: LocalPackage, config: &Config) -> Result<(), RemoveError> {

--- a/rocks-lib/src/operations/run.rs
+++ b/rocks-lib/src/operations/run.rs
@@ -6,9 +6,9 @@ use crate::{
     lockfile::PinnedState,
     package::{PackageReq, PackageVersionReqError},
     path::Paths,
+    progress::MultiProgress,
     tree::Tree,
 };
-use indicatif::MultiProgress;
 use thiserror::Error;
 
 use super::InstallError;

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -6,11 +6,11 @@ use crate::{
     lockfile::PinnedState,
     package::{PackageName, PackageReq, PackageVersionReqError},
     path::Paths,
+    progress::MultiProgress,
     project::Project,
     rockspec::Rockspec,
     tree::Tree,
 };
-use indicatif::MultiProgress;
 use itertools::Itertools;
 use thiserror::Error;
 

--- a/rocks-lib/src/operations/unpack.rs
+++ b/rocks-lib/src/operations/unpack.rs
@@ -1,26 +1,25 @@
-use crate::progress::with_spinner;
-
-use indicatif::MultiProgress;
 use std::io::Read;
 use std::io::Seek;
 use std::path::PathBuf;
 use thiserror::Error;
+
+use crate::progress::ProgressBar;
 
 #[derive(Error, Debug)]
 #[error("failed to unpack source rock: {0}")]
 pub struct UnpackError(#[from] zip::result::ZipError);
 
 pub async fn unpack_src_rock<R: Read + Seek + Send>(
-    progress: &MultiProgress,
+    progress: &ProgressBar,
     rock_src: R,
     destination: PathBuf,
 ) -> Result<PathBuf, UnpackError> {
-    with_spinner(
-        progress,
-        format!("📦 Unpacking src.rock into {}", destination.display()),
-        || async { unpack_src_rock_impl(rock_src, destination).await },
-    )
-    .await
+    progress.set_message(format!(
+        "📦 Unpacking src.rock into {}",
+        destination.display()
+    ));
+
+    unpack_src_rock_impl(rock_src, destination).await
 }
 
 async fn unpack_src_rock_impl<R: Read + Seek + Send>(
@@ -34,8 +33,8 @@ async fn unpack_src_rock_impl<R: Read + Seek + Send>(
 
 #[cfg(test)]
 mod tests {
+    use crate::progress::MultiProgress;
     use std::fs::File;
-
     use tempdir::TempDir;
 
     use super::*;
@@ -48,7 +47,7 @@ mod tests {
             .join("luatest-0.2-1.src.rock");
         let file = File::open(&test_rock_path).unwrap();
         let dest = TempDir::new("rocks-test").unwrap();
-        unpack_src_rock(&MultiProgress::new(), file, dest.into_path())
+        unpack_src_rock(&MultiProgress::new().new_bar(), file, dest.into_path())
             .await
             .unwrap();
     }

--- a/rocks-lib/src/progress.rs
+++ b/rocks-lib/src/progress.rs
@@ -1,32 +1,99 @@
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::{error::Error, time::Duration};
+use std::{borrow::Cow, time::Duration};
 
-pub async fn with_spinner<F, Fut, T, E>(
-    progress: &MultiProgress,
-    message: String,
-    callback: F,
-) -> Result<T, E>
-where
-    F: FnOnce() -> Fut + Send,
-    Fut: std::future::Future<Output = Result<T, E>> + Send,
-    T: Send + 'static,
-    E: Error,
-{
-    let spinner = progress.add(ProgressBar::new_spinner());
-    spinner.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} {msg}")
-            .unwrap(),
-    );
-    spinner.enable_steady_tick(Duration::from_millis(100));
-    spinner.set_message(message.clone());
-    callback()
-        .await
-        .map_err(|err| {
-            spinner.abandon_with_message(format!("{} failed: {}", message, err));
-            err
-        })
-        .inspect(|_| {
-            spinner.finish_with_message(format!("{} - Done.", message));
-        })
+pub struct MultiProgress(indicatif::MultiProgress);
+pub struct ProgressBar(indicatif::ProgressBar);
+
+impl MultiProgress {
+    pub fn new() -> Self {
+        Self(indicatif::MultiProgress::new())
+    }
+
+    pub fn add(&self, bar: ProgressBar) -> ProgressBar {
+        ProgressBar(self.0.insert_from_back(0, bar.0))
+    }
+
+    pub fn new_bar(&self) -> ProgressBar {
+        self.add(ProgressBar::new())
+    }
+
+    pub fn suspend<F, R>(&self, callback: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        self.0.suspend(callback)
+    }
+}
+
+impl Default for MultiProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProgressBar {
+    pub fn new() -> Self {
+        let bar =
+            indicatif::ProgressBar::new_spinner().with_finish(indicatif::ProgressFinish::AndClear);
+        bar.enable_steady_tick(Duration::from_millis(100));
+
+        Self(bar)
+    }
+
+    pub fn into_raw(self) -> indicatif::ProgressBar {
+        self.0
+    }
+
+    pub fn set_message<M>(&self, message: M)
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        self.0.set_message(message)
+    }
+
+    pub fn set_position(&self, position: u64) {
+        self.0.set_position(position)
+    }
+
+    pub fn position(&self) -> u64 {
+        self.0.position()
+    }
+
+    pub fn println<M>(&self, message: M)
+    where
+        M: AsRef<str>,
+    {
+        self.0.println(message)
+    }
+
+    pub fn finish_with_message<M>(self, message: M)
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        self.0.finish_with_message(message)
+    }
+
+    pub fn finish_and_clear(self) {
+        self.0.finish_and_clear()
+    }
+}
+
+impl Default for ProgressBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<String> for ProgressBar {
+    fn from(message: String) -> Self {
+        Self(Self::new().0.with_message(message))
+    }
+}
+
+impl From<u64> for ProgressBar {
+    fn from(position: u64) -> Self {
+        let new = Self::new();
+        new.set_position(position);
+
+        new
+    }
 }

--- a/rocks-lib/src/rockspec/build/mod.rs
+++ b/rocks-lib/src/rockspec/build/mod.rs
@@ -6,7 +6,6 @@ mod rust_mlua;
 pub mod utils; // Make build utilities available as a submodule
 pub use builtin::{BuiltinBuildSpec, LuaModule, ModulePaths, ModuleSpec};
 pub use cmake::*;
-use indicatif::MultiProgress;
 pub use make::*;
 pub use rust_mlua::*;
 
@@ -29,7 +28,9 @@ use thiserror::Error;
 
 use serde::{de, de::IntoDeserializer, Deserialize, Deserializer};
 
-use crate::{config::Config, lua_installation::LuaInstallation, tree::RockLayout};
+use crate::{
+    config::Config, lua_installation::LuaInstallation, progress::ProgressBar, tree::RockLayout,
+};
 
 use super::{
     mlua_json_value_to_vec, LuaTableKey, PartialOverride, PerPlatform, PlatformIdentifier,
@@ -526,7 +527,7 @@ pub trait Build {
 
     fn run(
         self,
-        progress: &MultiProgress,
+        progress: &ProgressBar,
         output_paths: &RockLayout,
         no_install: bool,
         lua: &LuaInstallation,

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -1,5 +1,3 @@
-use mlua::{ExternalResult as _, Function};
-
 use crate::{
     build::variables::{self, HasVariables},
     config::LuaVersion,
@@ -7,6 +5,9 @@ use crate::{
     package::PackageReq,
 };
 use std::{io, path::PathBuf};
+
+#[cfg(feature = "lua")]
+use mlua::ExternalResult as _;
 
 mod list;
 
@@ -205,7 +206,7 @@ impl mlua::UserData for Tree {
         });
         methods.add_method(
             "has_rock_and",
-            |_, this, (req, callback): (PackageReq, Function)| {
+            |_, this, (req, callback): (PackageReq, mlua::Function)| {
                 Ok(this.has_rock_and(&req, |package| {
                     callback
                         .call(package.clone())

--- a/rocks-lib/tests/build.rs
+++ b/rocks-lib/tests/build.rs
@@ -1,8 +1,8 @@
-use indicatif::MultiProgress;
 use rocks_lib::{
     build::{self, BuildBehaviour::Force},
     config::{ConfigBuilder, LuaVersion},
     lockfile::{LockConstraint::Unconstrained, PinnedState::Unpinned},
+    progress::MultiProgress,
     rockspec::Rockspec,
 };
 use tempdir::TempDir;
@@ -22,16 +22,12 @@ async fn builtin_build() {
         .build()
         .unwrap();
 
-    build::build(
-        &MultiProgress::new(),
-        rockspec,
-        Unpinned,
-        Unconstrained,
-        Force,
-        &config,
-    )
-    .await
-    .unwrap();
+    let progress = MultiProgress::new();
+    let bar = progress.new_bar();
+
+    build::build(&bar, rockspec, Unpinned, Unconstrained, Force, &config)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -50,14 +46,10 @@ async fn make_build() {
         .build()
         .unwrap();
 
-    build::build(
-        &MultiProgress::new(),
-        rockspec,
-        Unpinned,
-        Unconstrained,
-        Force,
-        &config,
-    )
-    .await
-    .unwrap();
+    let progress = MultiProgress::new();
+    let bar = progress.new_bar();
+
+    build::build(&bar, rockspec, Unpinned, Unconstrained, Force, &config)
+        .await
+        .unwrap();
 }

--- a/rocks-lib/tests/test.rs
+++ b/rocks-lib/tests/test.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
-use indicatif::MultiProgress;
 use rocks_lib::{
     config::{ConfigBuilder, LuaVersion},
     operations::{ensure_busted, run_tests, TestEnv},
+    progress::MultiProgress,
     project::Project,
     tree::Tree,
 };


### PR DESCRIPTION
~~Still *loads* of work left to do with this PR, so don't review yet.~~

This PR refactors the CLI experience. We stop exposing a library struct and instead create our own newtype wrappers. These wrappers are then propagated throughout the codebase. In addition, instead of sending MultiProgresses everywhere, we now primarily send ProgressBars, since most operations operate on a single thing and only need a single progress bar to display progress.