### PR TITLE
fix(list): show package name only once

### DIFF
--- a/rocks-bin/src/list.rs
+++ b/rocks-bin/src/list.rs
@@ -27,8 +27,7 @@ pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
 
             for package in packages {
                 tree.push(format!(
-                    "{} {}{}",
-                    package.name(),
+                    "{}{}",
                     package.version(),
                     if package.pinned() == PinnedState::Pinned {
                         " (pinned)"


### PR DESCRIPTION
Fixes a slight annoyance where the package name would be displayed multiple times in `rocks list` output.