### PR TITLE
fix(install): properly assign dependencies in the lockfile

### DIFF
--- a/rocks-lib/src/rockspec/build/mod.rs
+++ b/rocks-lib/src/rockspec/build/mod.rs
@@ -40,7 +40,7 @@ use super::{
 ///
 /// See [the rockspec format](https://github.com/luarocks/luarocks/wiki/Rockspec-format) for more
 /// info.
-#[derive(Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct BuildSpec {
     /// Determines the build backend to use.
     pub build_backend: Option<BuildBackendSpec>,

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -36,7 +36,7 @@ pub enum RockspecError {
     LuaTable(#[from] LuaTableError),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Rockspec {
     /// The file format version. Example: "1.0"
     pub rockspec_format: Option<RockspecFormat>,
@@ -178,7 +178,7 @@ impl HasIntegrity for Rockspec {
     }
 }
 
-#[derive(Deserialize, Debug, PartialEq, Default)]
+#[derive(Clone, Deserialize, Debug, PartialEq, Default)]
 pub struct RockDescription {
     /// A one-line description of the package.
     pub summary: Option<String>,
@@ -201,7 +201,7 @@ pub struct RockDescription {
 #[error("invalid rockspec format: {0}")]
 pub struct InvalidRockspecFormat(String);
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RockspecFormat {
     #[serde(rename = "1.0")]
     _1_0,

--- a/rocks-lib/src/rockspec/platform.rs
+++ b/rocks-lib/src/rockspec/platform.rs
@@ -100,7 +100,7 @@ impl PlatformIdentifier {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PlatformSupport {
     /// Do not match this platform
     platform_map: HashMap<PlatformIdentifier, bool>,
@@ -272,7 +272,7 @@ pub trait FromPlatformOverridable<T: PlatformOverridable, G: FromPlatformOverrid
 }
 
 /// Data that that can vary per platform
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PerPlatform<T> {
     /// The base data, applicable if no platform is specified
     pub default: T,

--- a/rocks-lib/src/rockspec/rock_source.rs
+++ b/rocks-lib/src/rockspec/rock_source.rs
@@ -10,7 +10,7 @@ use super::{
     FromPlatformOverridable, PartialOverride, PerPlatform, PerPlatformWrapper, PlatformOverridable,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RockSource {
     pub source_spec: RockSourceSpec,
     pub integrity: Option<Integrity>,

--- a/rocks-lib/src/rockspec/test_spec.rs
+++ b/rocks-lib/src/rockspec/test_spec.rs
@@ -9,7 +9,7 @@ use super::{
     FromPlatformOverridable, PartialOverride, PerPlatform, PerPlatformWrapper, PlatformOverridable,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TestSpec {
     AutoDetect,
     Busted(BustedTestSpec),
@@ -67,18 +67,18 @@ impl FromLua for PerPlatform<TestSpec> {
     }
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct BustedTestSpec {
     flags: Vec<String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CommandTestSpec {
     command: String,
     flags: Vec<String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ScriptTestSpec {
     script: PathBuf,
     flags: Vec<String>,


### PR DESCRIPTION
This PR accumulates the IDs of rocks during the initial dependency search, creating a dependency graph as it chugs along. After installing the required packages, this dependency graph is referenced to properly build up the lockfile.

To test this, first `rocks purge` your tree, which will also remove the `lock.json`. Then, install your favourite package and `cat /my/tree/5.4/lock.json` :)