### PR TITLE
refactor!: make progress indicators optional

### DIFF
--- a/rocks-bin/src/download.rs
+++ b/rocks-bin/src/download.rs
@@ -1,7 +1,10 @@
 use clap::Args;
 use eyre::Result;
 use rocks_lib::{
-    config::Config, manifest::ManifestMetadata, package::PackageReq, progress::MultiProgress,
+    config::Config,
+    manifest::ManifestMetadata,
+    package::PackageReq,
+    progress::{MultiProgress, Progress},
 };
 
 #[derive(Args)]
@@ -12,21 +15,23 @@ pub struct Download {
 pub async fn download(dl_data: Download, config: Config) -> Result<()> {
     let manifest = ManifestMetadata::from_config(&config).await?;
     let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::Progress(progress.new_bar());
 
     let rock = rocks_lib::operations::download_to_file(
-        &bar,
         &dl_data.package_req,
         None,
         &manifest,
         &config,
+        &bar,
     )
     .await?;
 
-    bar.finish_with_message(format!(
-        "Succesfully downloaded {}@{}",
-        rock.name, rock.version
-    ));
+    bar.map(|b| {
+        b.finish_with_message(format!(
+            "Succesfully downloaded {}@{}",
+            rock.name, rock.version
+        ))
+    });
 
     Ok(())
 }

--- a/rocks-bin/src/fetch.rs
+++ b/rocks-bin/src/fetch.rs
@@ -1,23 +1,27 @@
 use std::path::PathBuf;
 
 use eyre::Result;
-use rocks_lib::{config::Config, manifest::ManifestMetadata, progress::MultiProgress};
+use rocks_lib::{
+    config::Config,
+    manifest::ManifestMetadata,
+    progress::{MultiProgress, Progress},
+};
 
 use crate::unpack::UnpackRemote;
 
 pub async fn fetch_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let package_req = data.package_req;
     let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::Progress(progress.new_bar());
     let manifest = ManifestMetadata::from_config(&config).await?;
     let rockspec =
-        rocks_lib::operations::download_rockspec(&bar, &package_req, &manifest, &config).await?;
+        rocks_lib::operations::download_rockspec(&package_req, &manifest, &config, &bar).await?;
 
     let destination = data
         .path
         .unwrap_or_else(|| PathBuf::from(format!("{}-{}", &rockspec.package, &rockspec.version)));
     let rock_source = rockspec.source.current_platform();
-    rocks_lib::operations::fetch_src(&bar, destination.clone().as_path(), rock_source).await?;
+    rocks_lib::operations::fetch_src(destination.clone().as_path(), rock_source, &bar).await?;
 
     let build_dir = rock_source
         .unpack_dir
@@ -25,14 +29,16 @@ pub async fn fetch_remote(data: UnpackRemote, config: Config) -> Result<()> {
         .map(|path| destination.join(path))
         .unwrap_or_else(|| destination);
 
-    bar.finish_with_message(format!(
-        "
+    bar.map(|b| {
+        b.finish_with_message(format!(
+            "
 You may now enter the following directory:
 {}
 and type `rocks build` to build.
     ",
-        build_dir.as_path().display()
-    ));
+            build_dir.as_path().display()
+        ))
+    });
 
     Ok(())
 }

--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -5,7 +5,7 @@ use rocks_lib::{
     manifest::ManifestMetadata,
     operations::download_rockspec,
     package::PackageReq,
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     tree::Tree,
 };
 
@@ -20,11 +20,11 @@ pub async fn info(data: Info, config: Config) -> Result<()> {
     let manifest = ManifestMetadata::from_config(&config).await?;
 
     let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::Progress(progress.new_bar());
 
-    let rockspec = download_rockspec(&bar, &data.package, &manifest, &config).await?;
+    let rockspec = download_rockspec(&data.package, &manifest, &config, &bar).await?;
 
-    bar.finish_and_clear();
+    bar.map(|b| b.finish_and_clear());
 
     if tree.has_rock(&data.package).is_some() {
         println!("Currently installed in {}", tree.root().display());

--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -7,7 +7,7 @@ use rocks_lib::{
     lockfile::PinnedState,
     manifest::ManifestMetadata,
     package::PackageReq,
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     tree::Tree,
 };
 
@@ -57,8 +57,14 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
     let manifest = ManifestMetadata::from_config(&config).await?;
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
-    rocks_lib::operations::install(&MultiProgress::new(), packages, pin, &manifest, &config)
-        .await?;
+    rocks_lib::operations::install(
+        packages,
+        pin,
+        &manifest,
+        &config,
+        &Progress::Progress(MultiProgress::new()),
+    )
+    .await?;
 
     Ok(())
 }

--- a/rocks-bin/src/remove.rs
+++ b/rocks-bin/src/remove.rs
@@ -4,7 +4,7 @@ use rocks_lib::{
     config::{Config, LuaVersion},
     manifest::{manifest_from_server, ManifestMetadata},
     package::{PackageName, PackageVersion, RemotePackage},
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     tree::Tree,
 };
 
@@ -31,12 +31,12 @@ pub async fn remove(remove_args: Remove, config: Config) -> Result<()> {
     match tree.has_rock(
         &RemotePackage::new(remove_args.name.clone(), target_version.clone()).into_package_req(),
     ) {
-        Some(package) => {
-            Ok(
-                rocks_lib::operations::remove(&MultiProgress::new().new_bar(), package, &config)
-                    .await?,
-            )
-        }
+        Some(package) => Ok(rocks_lib::operations::remove(
+            package,
+            &config,
+            &Progress::Progress(MultiProgress::new().new_bar()),
+        )
+        .await?),
         None => {
             eprintln!("Could not find {}@{}", remove_args.name, target_version);
             Ok(())

--- a/rocks-bin/src/test.rs
+++ b/rocks-bin/src/test.rs
@@ -4,7 +4,7 @@ use rocks_lib::{
     config::Config,
     manifest::ManifestMetadata,
     operations::{ensure_busted, ensure_dependencies, run_tests, TestEnv},
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     project::Project,
     tree::Tree,
 };
@@ -32,10 +32,10 @@ pub async fn test(test: Test, config: Config) -> Result<()> {
         test_config.tree().clone(),
         test_config.lua_version().unwrap().clone(),
     )?;
-    let progress = MultiProgress::new();
+    let progress = Progress::Progress(MultiProgress::new());
     // TODO(#204): Only ensure busted if running with busted (e.g. a .busted directory exists)
-    ensure_busted(&progress, &tree, &manifest, &test_config).await?;
-    ensure_dependencies(&progress, rockspec, &tree, &manifest, &test_config).await?;
+    ensure_busted(&tree, &manifest, &test_config, &progress).await?;
+    ensure_dependencies(rockspec, &tree, &manifest, &test_config, &progress).await?;
     let test_args = test.test_args.unwrap_or_default();
     let test_env = if test.impure {
         TestEnv::Impure

--- a/rocks-lib/src/build/make.rs
+++ b/rocks-lib/src/build/make.rs
@@ -10,7 +10,7 @@ use crate::{
     build::variables::HasVariables,
     config::Config,
     lua_installation::LuaInstallation,
-    progress::ProgressBar,
+    progress::{Progress, ProgressBar},
     rockspec::{Build, MakeBuildSpec},
     tree::RockLayout,
 };
@@ -36,12 +36,12 @@ impl Build for MakeBuildSpec {
 
     async fn run(
         self,
-        _progress: &ProgressBar,
         output_paths: &RockLayout,
         no_install: bool,
         lua: &LuaInstallation,
         config: &Config,
         build_dir: &Path,
+        _progress: &Progress<ProgressBar>,
     ) -> Result<(), Self::Err> {
         // Build step
         if self.build_pass {

--- a/rocks-lib/src/operations/remove.rs
+++ b/rocks-lib/src/operations/remove.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use crate::config::{LuaVersion, LuaVersionUnset};
 use crate::lockfile::LocalPackage;
-use crate::progress::ProgressBar;
+use crate::progress::{Progress, ProgressBar};
 use crate::{config::Config, tree::Tree};
 use thiserror::Error;
 
@@ -15,15 +15,17 @@ pub enum RemoveError {
 
 // TODO: Remove dependencies recursively too!
 pub async fn remove(
-    progress: &ProgressBar,
     package: LocalPackage,
     config: &Config,
+    progress: &Progress<ProgressBar>,
 ) -> Result<(), RemoveError> {
-    progress.set_message(format!(
-        "🗑️ Removing {}@{}",
-        package.name(),
-        package.version()
-    ));
+    progress.map(|p| {
+        p.set_message(format!(
+            "🗑️ Removing {}@{}",
+            package.name(),
+            package.version()
+        ))
+    });
 
     remove_impl(package, config).await
 }

--- a/rocks-lib/src/operations/run.rs
+++ b/rocks-lib/src/operations/run.rs
@@ -7,7 +7,7 @@ use crate::{
     manifest::{ManifestError, ManifestMetadata},
     package::{PackageReq, PackageVersionReqError},
     path::Paths,
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     tree::Tree,
 };
 use thiserror::Error;
@@ -61,11 +61,11 @@ pub async fn install_command(command: &str, config: &Config) -> Result<(), Insta
     let package_req = PackageReq::new(command.into(), None)?;
     let manifest = ManifestMetadata::from_config(config).await?;
     super::install(
-        &MultiProgress::new(),
         vec![(BuildBehaviour::NoForce, package_req)],
         PinnedState::Unpinned,
         &manifest,
         config,
+        &Progress::Progress(MultiProgress::new()),
     )
     .await?;
     Ok(())

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -7,7 +7,7 @@ use crate::{
     manifest::ManifestMetadata,
     package::{PackageName, PackageReq, PackageVersionReqError},
     path::Paths,
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     project::Project,
     rockspec::Rockspec,
     tree::Tree,
@@ -100,20 +100,20 @@ pub enum InstallTestDependenciesError {
 /// Ensure that busted is installed.
 /// This defaults to the local project tree if cwd is a project root.
 pub async fn ensure_busted(
-    progress: &MultiProgress,
     tree: &Tree,
     manifest: &ManifestMetadata,
     config: &Config,
+    progress: &Progress<MultiProgress>,
 ) -> Result<(), InstallTestDependenciesError> {
     let busted_req = PackageReq::new("busted".into(), None)?;
 
     if tree.has_rock(&busted_req).is_none() {
         install(
-            progress,
             vec![(BuildBehaviour::NoForce, busted_req)],
             PinnedState::Unpinned,
             manifest,
             config,
+            progress,
         )
         .await?;
     }
@@ -124,11 +124,11 @@ pub async fn ensure_busted(
 /// Ensure dependencies and test dependencies are installed
 /// This defaults to the local project tree if cwd is a project root.
 pub async fn ensure_dependencies(
-    progress: &MultiProgress,
     rockspec: &Rockspec,
     tree: &Tree,
     manifest: &ManifestMetadata,
     config: &Config,
+    progress: &Progress<MultiProgress>,
 ) -> Result<(), InstallTestDependenciesError> {
     let dependencies = rockspec
         .test_dependencies
@@ -147,11 +147,11 @@ pub async fn ensure_dependencies(
         .collect_vec();
 
     install(
-        progress,
         dependencies,
         PinnedState::Unpinned,
         manifest,
         config,
+        progress,
     )
     .await?;
 

--- a/rocks-lib/src/rockspec/build/mod.rs
+++ b/rocks-lib/src/rockspec/build/mod.rs
@@ -29,7 +29,10 @@ use thiserror::Error;
 use serde::{de, de::IntoDeserializer, Deserialize, Deserializer};
 
 use crate::{
-    config::Config, lua_installation::LuaInstallation, progress::ProgressBar, tree::RockLayout,
+    config::Config,
+    lua_installation::LuaInstallation,
+    progress::{Progress, ProgressBar},
+    tree::RockLayout,
 };
 
 use super::{
@@ -527,12 +530,12 @@ pub trait Build {
 
     fn run(
         self,
-        progress: &ProgressBar,
         output_paths: &RockLayout,
         no_install: bool,
         lua: &LuaInstallation,
         config: &Config,
         build_dir: &Path,
+        progress: &Progress<ProgressBar>,
     ) -> impl Future<Output = Result<(), Self::Err>> + Send;
 }
 

--- a/rocks-lib/tests/build.rs
+++ b/rocks-lib/tests/build.rs
@@ -2,7 +2,7 @@ use rocks_lib::{
     build::{self, BuildBehaviour::Force},
     config::ConfigBuilder,
     lockfile::{LockConstraint::Unconstrained, PinnedState::Unpinned},
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     rockspec::Rockspec,
 };
 use tempdir::TempDir;
@@ -24,9 +24,16 @@ async fn builtin_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    build::build(&bar, rockspec, Unpinned, Unconstrained, Force, &config)
-        .await
-        .unwrap();
+    build::build(
+        rockspec,
+        Unpinned,
+        Unconstrained,
+        Force,
+        &config,
+        &Progress::Progress(bar),
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -47,7 +54,14 @@ async fn make_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    build::build(&bar, rockspec, Unpinned, Unconstrained, Force, &config)
-        .await
-        .unwrap();
+    build::build(
+        rockspec,
+        Unpinned,
+        Unconstrained,
+        Force,
+        &config,
+        &Progress::Progress(bar),
+    )
+    .await
+    .unwrap();
 }

--- a/rocks-lib/tests/test.rs
+++ b/rocks-lib/tests/test.rs
@@ -4,7 +4,7 @@ use rocks_lib::{
     config::ConfigBuilder,
     manifest::ManifestMetadata,
     operations::{ensure_busted, run_tests, TestEnv},
-    progress::MultiProgress,
+    progress::{MultiProgress, Progress},
     project::Project,
     tree::Tree,
 };
@@ -19,9 +19,14 @@ async fn run_busted_test() {
     let config = ConfigBuilder::new().tree(Some(tree_root)).build().unwrap();
     let tree = Tree::new(config.tree().clone(), config.lua_version().unwrap().clone()).unwrap();
     let manifest = ManifestMetadata::from_config(&config).await.unwrap();
-    ensure_busted(&MultiProgress::new(), &tree, &manifest, &config)
-        .await
-        .unwrap();
+    ensure_busted(
+        &tree,
+        &manifest,
+        &config,
+        &Progress::Progress(MultiProgress::new()),
+    )
+    .await
+    .unwrap();
     run_tests(project, Vec::new(), TestEnv::Pure, config)
         .await
         .unwrap()


### PR DESCRIPTION
This refactors the entire library to allow progress indicators to be optional (crucial for #201).

This introduces a sealed trait called `HasProgress` and an enum called `Progress`. These allow the usage of either `MultiProgress` or `ProgressBar` in a similar fashion to how you would use an `Option<T>`.

Note: this PR doesn't implement a `--silent` flag of any kind, and continues to assume that `Progress` should always be displayed through the CLI. This PR serves as the skeleton for that feature, which may be implemented in a separate PR.

Let me know what you think @mrcjkb.