### PR TITLE
fix: duplicated progress bars

### DIFF
--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -7,7 +7,7 @@ use rocks_lib::{
     lockfile::PinnedState,
     manifest::ManifestMetadata,
     package::PackageReq,
-    progress::{MultiProgress, Progress},
+    progress::MultiProgress,
     tree::Tree,
 };
 
@@ -57,14 +57,8 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
     let manifest = ManifestMetadata::from_config(&config).await?;
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
-    rocks_lib::operations::install(
-        packages,
-        pin,
-        &manifest,
-        &config,
-        &Progress::Progress(MultiProgress::new()),
-    )
-    .await?;
+    rocks_lib::operations::install(packages, pin, &manifest, &config, MultiProgress::new_arc())
+        .await?;
 
     Ok(())
 }

--- a/rocks-bin/src/test.rs
+++ b/rocks-bin/src/test.rs
@@ -4,7 +4,7 @@ use rocks_lib::{
     config::Config,
     manifest::ManifestMetadata,
     operations::{ensure_busted, ensure_dependencies, run_tests, TestEnv},
-    progress::{MultiProgress, Progress},
+    progress::MultiProgress,
     project::Project,
     tree::Tree,
 };
@@ -32,10 +32,10 @@ pub async fn test(test: Test, config: Config) -> Result<()> {
         test_config.tree().clone(),
         test_config.lua_version().unwrap().clone(),
     )?;
-    let progress = Progress::Progress(MultiProgress::new());
+    let progress = MultiProgress::new_arc();
     // TODO(#204): Only ensure busted if running with busted (e.g. a .busted directory exists)
-    ensure_busted(&tree, &manifest, &test_config, &progress).await?;
-    ensure_dependencies(rockspec, &tree, &manifest, &test_config, &progress).await?;
+    ensure_busted(&tree, &manifest, &test_config, progress.clone()).await?;
+    ensure_dependencies(rockspec, &tree, &manifest, &test_config, progress).await?;
     let test_args = test.test_args.unwrap_or_default();
     let test_env = if test.impure {
         TestEnv::Impure

--- a/rocks-bin/src/update.rs
+++ b/rocks-bin/src/update.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::config::LuaVersion;
 use rocks_lib::lockfile::PinnedState;
-use rocks_lib::progress::{MultiProgress, Progress, ProgressBar};
+use rocks_lib::progress::{MultiProgress, ProgressBar};
 use rocks_lib::{
     config::Config, manifest::ManifestMetadata, operations, package::PackageReq, tree::Tree,
 };
@@ -11,7 +11,7 @@ use rocks_lib::{
 pub struct Update {}
 
 pub async fn update(config: Config) -> Result<()> {
-    let progress = Progress::Progress(MultiProgress::new());
+    let progress = MultiProgress::new_arc();
     progress.map(|p| p.add(ProgressBar::from("🔎 Looking for updates...".to_string())));
 
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
@@ -30,7 +30,7 @@ pub async fn update(config: Config) -> Result<()> {
                 )?,
                 &manifest,
                 &config,
-                &progress,
+                progress.clone(),
             )
             .await?;
         }

--- a/rocks-lib/src/operations/resolve.rs
+++ b/rocks-lib/src/operations/resolve.rs
@@ -32,13 +32,13 @@ pub(crate) async fn get_all_dependencies(
     pin: PinnedState,
     manifest: Arc<ManifestMetadata>,
     config: &Config,
-    progress: &Progress<MultiProgress>,
+    progress: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackageId>, SearchAndDownloadError> {
     join_all(packages.into_iter().map(|(build_behaviour, package)| {
         let config = config.clone();
         let tx = tx.clone();
-        let progress = progress.clone();
         let manifest = Arc::clone(&manifest);
+        let progress = Arc::clone(&progress);
 
         tokio::spawn(async move {
             let bar = progress.map(|p| p.new_bar());
@@ -63,7 +63,7 @@ pub(crate) async fn get_all_dependencies(
                 .collect_vec();
 
             let dependencies =
-                get_all_dependencies(tx.clone(), dependencies, pin, manifest, &config, &progress)
+                get_all_dependencies(tx.clone(), dependencies, pin, manifest, &config, progress)
                     .await?;
 
             let local_spec = LocalPackageSpec::new(

--- a/rocks-lib/src/operations/run.rs
+++ b/rocks-lib/src/operations/run.rs
@@ -7,7 +7,7 @@ use crate::{
     manifest::{ManifestError, ManifestMetadata},
     package::{PackageReq, PackageVersionReqError},
     path::Paths,
-    progress::{MultiProgress, Progress},
+    progress::MultiProgress,
     tree::Tree,
 };
 use thiserror::Error;
@@ -65,7 +65,7 @@ pub async fn install_command(command: &str, config: &Config) -> Result<(), Insta
         PinnedState::Unpinned,
         &manifest,
         config,
-        &Progress::Progress(MultiProgress::new()),
+        MultiProgress::new_arc(),
     )
     .await?;
     Ok(())

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -1,4 +1,4 @@
-use std::{io, process::Command};
+use std::{io, process::Command, sync::Arc};
 
 use crate::{
     build::BuildBehaviour,
@@ -103,7 +103,7 @@ pub async fn ensure_busted(
     tree: &Tree,
     manifest: &ManifestMetadata,
     config: &Config,
-    progress: &Progress<MultiProgress>,
+    progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), InstallTestDependenciesError> {
     let busted_req = PackageReq::new("busted".into(), None)?;
 
@@ -128,7 +128,7 @@ pub async fn ensure_dependencies(
     tree: &Tree,
     manifest: &ManifestMetadata,
     config: &Config,
-    progress: &Progress<MultiProgress>,
+    progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), InstallTestDependenciesError> {
     let dependencies = rockspec
         .test_dependencies

--- a/rocks-lib/src/operations/update.rs
+++ b/rocks-lib/src/operations/update.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use thiserror::Error;
 
 use crate::{
@@ -34,7 +36,7 @@ pub async fn update(
     constraint: PackageReq,
     manifest: &ManifestMetadata,
     config: &Config,
-    progress: &Progress<MultiProgress>,
+    progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), UpdateError> {
     let bar = progress.map(|p| p.add(ProgressBar::from(format!("Updating {}...", package.name()))));
 

--- a/rocks-lib/src/progress.rs
+++ b/rocks-lib/src/progress.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::Duration};
+use std::{borrow::Cow, sync::Arc, time::Duration};
 
 mod private {
     pub trait HasProgress {}
@@ -34,13 +34,17 @@ where
     }
 }
 
-#[derive(Clone)]
+// WARNING: Don't implement `Clone` for this.
 pub struct MultiProgress(indicatif::MultiProgress);
 pub struct ProgressBar(indicatif::ProgressBar);
 
 impl MultiProgress {
     pub fn new() -> Self {
         Self(indicatif::MultiProgress::new())
+    }
+
+    pub fn new_arc() -> Arc<Progress<MultiProgress>> {
+        Arc::new(Progress::Progress(MultiProgress::new()))
     }
 
     pub fn add(&self, bar: ProgressBar) -> ProgressBar {

--- a/rocks-lib/tests/test.rs
+++ b/rocks-lib/tests/test.rs
@@ -4,7 +4,7 @@ use rocks_lib::{
     config::ConfigBuilder,
     manifest::ManifestMetadata,
     operations::{ensure_busted, run_tests, TestEnv},
-    progress::{MultiProgress, Progress},
+    progress::MultiProgress,
     project::Project,
     tree::Tree,
 };
@@ -19,14 +19,9 @@ async fn run_busted_test() {
     let config = ConfigBuilder::new().tree(Some(tree_root)).build().unwrap();
     let tree = Tree::new(config.tree().clone(), config.lua_version().unwrap().clone()).unwrap();
     let manifest = ManifestMetadata::from_config(&config).await.unwrap();
-    ensure_busted(
-        &tree,
-        &manifest,
-        &config,
-        &Progress::Progress(MultiProgress::new()),
-    )
-    .await
-    .unwrap();
+    ensure_busted(&tree, &manifest, &config, MultiProgress::new_arc())
+        .await
+        .unwrap();
     run_tests(project, Vec::new(), TestEnv::Pure, config)
         .await
         .unwrap()


### PR DESCRIPTION
I think cloning a `MultiProgress` could be leading to strange behaviour.
This should fix it.