### PR TITLE
feat(build): fail if `external_dependencies` can't be found

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
                   pkg-config
                   libxcrypt
                   cmakeMinimal
+                  zlib
                 ])
                 ++ self.checks.${system}.git-hooks-check.enabledPackages
                 ++ pkgs.rocks.buildInputs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -33,6 +33,7 @@
         nativeCheckInputs = [
           cacert
           cargo-nextest
+          zlib # used for checking external dependencies
         ];
 
         preCheck = ''

--- a/rocks-lib/src/build/external_dependency.rs
+++ b/rocks-lib/src/build/external_dependency.rs
@@ -1,0 +1,449 @@
+use pkg_config::{Config as PkgConfig, Library};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+use crate::{
+    config::external_deps::ExternalDependencySearchConfig, rockspec::ExternalDependencySpec,
+};
+
+#[derive(Error, Debug)]
+pub enum ExternalDependencyError {
+    #[error("{}", not_found_error_msg(.0))]
+    NotFound(String),
+    #[error("IO error while trying to detect external dependencies: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug)]
+pub enum ExternalDependencyInfo {
+    /// Detected via pkg-config
+    PkgConfig(Library),
+    /// Library, detected via fallback mechanism
+    Library {
+        prefix: PathBuf,
+        include_dir: PathBuf,
+        lib_dir: PathBuf,
+        lib_file: PathBuf,
+    },
+    /// Header-only dependency, detected vial fallback mechanism
+    HeaderOnly {
+        prefix: PathBuf,
+        include_dir: PathBuf,
+    },
+}
+
+impl ExternalDependencyInfo {
+    pub fn detect(
+        name: &str,
+        dependency: &ExternalDependencySpec,
+        config: &ExternalDependencySearchConfig,
+    ) -> Result<Self, ExternalDependencyError> {
+        let mut lib_info = PkgConfig::new()
+            .print_system_libs(false)
+            .cargo_metadata(false)
+            .probe(&name.to_lowercase())
+            .ok();
+        if lib_info.is_none() {
+            if let ExternalDependencySpec::Library(lib) = dependency {
+                // Strip "lib" prefix and extension if present
+                let file_name = lib.file_name().and_then(|f| f.to_str()).unwrap_or(name);
+                let lib_name = if file_name.starts_with("lib") {
+                    file_name.strip_prefix("lib").unwrap()
+                } else {
+                    file_name
+                };
+                let probe = if let Some(name_without_ext) = lib_name.split('.').next() {
+                    name_without_ext
+                } else {
+                    lib_name
+                };
+                lib_info = PkgConfig::new()
+                    .print_system_libs(false)
+                    .cargo_metadata(false)
+                    .probe(probe)
+                    .ok();
+            }
+        }
+        if let Some(info) = lib_info {
+            match dependency {
+                ExternalDependencySpec::Header(header) => {
+                    if info
+                        .include_paths
+                        .iter()
+                        .any(|path| path.join(header).exists())
+                    {
+                        return Ok(Self::PkgConfig(info));
+                    }
+                }
+                ExternalDependencySpec::Library(_) => {
+                    return Ok(Self::PkgConfig(info));
+                }
+            }
+        }
+        Self::fallback_detect(name, dependency, config)
+    }
+
+    fn fallback_detect(
+        name: &str,
+        dependency: &ExternalDependencySpec,
+        config: &ExternalDependencySearchConfig,
+    ) -> Result<Self, ExternalDependencyError> {
+        let env_prefix = std::env::var(format!("{}_DIR", name.to_uppercase())).ok();
+
+        let mut search_prefixes = Vec::new();
+        if let Some(dir) = env_prefix {
+            search_prefixes.push(PathBuf::from(dir));
+        }
+        if let Some(prefix) = config.prefixes.get(&format!("{}_DIR", name.to_uppercase())) {
+            search_prefixes.push(prefix.clone());
+        }
+        search_prefixes.extend(config.search_prefixes.iter().cloned());
+
+        match dependency {
+            ExternalDependencySpec::Header(header) => {
+                if let Some(inc_dir) = get_incdir(name, config) {
+                    if inc_dir.join(header).exists() {
+                        return Ok(Self::HeaderOnly {
+                            prefix: inc_dir.parent().unwrap_or(&inc_dir).to_path_buf(),
+                            include_dir: inc_dir,
+                        });
+                    }
+                }
+
+                // Search prefixes
+                for prefix in search_prefixes {
+                    let inc_dir = prefix.join(&config.include_subdir);
+                    if inc_dir.join(header).exists() {
+                        return Ok(Self::HeaderOnly {
+                            prefix: prefix.clone(),
+                            include_dir: inc_dir,
+                        });
+                    }
+                }
+
+                Err(ExternalDependencyError::NotFound(name.into()))
+            }
+            ExternalDependencySpec::Library(lib) => {
+                // Check for specific directory overrides first
+                if let (Some(inc_dir), Some(lib_dir)) =
+                    (get_incdir(name, config), get_libdir(name, config))
+                {
+                    if library_exists(&lib_dir, lib, &config.lib_patterns) {
+                        return Ok(Self::Library {
+                            prefix: inc_dir.parent().unwrap_or(&inc_dir).to_path_buf(),
+                            include_dir: inc_dir,
+                            lib_dir,
+                            lib_file: lib.clone(),
+                        });
+                    }
+                }
+                for prefix in search_prefixes {
+                    let inc_dir = prefix.join(&config.include_subdir);
+                    for lib_subdir in &config.lib_subdir {
+                        let lib_dir = prefix.join(lib_subdir);
+                        if library_exists(&lib_dir, lib, &config.lib_patterns) {
+                            return Ok(Self::Library {
+                                prefix: prefix.clone(),
+                                include_dir: inc_dir,
+                                lib_dir,
+                                lib_file: lib.clone(),
+                            });
+                        }
+                    }
+                }
+
+                Err(ExternalDependencyError::NotFound(name.into()))
+            }
+        }
+    }
+}
+
+fn library_exists(lib_dir: &Path, lib: &Path, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
+        let file_name = pattern.replace('?', &format!("{}", lib.display()));
+        lib_dir.join(&file_name).exists()
+    })
+}
+
+fn get_incdir(name: &str, config: &ExternalDependencySearchConfig) -> Option<PathBuf> {
+    let var_name = format!("{}_INCDIR", name.to_uppercase());
+    if let Ok(env_incdir) = std::env::var(&var_name) {
+        Some(env_incdir.into())
+    } else {
+        config.prefixes.get(&var_name).cloned()
+    }
+}
+
+fn get_libdir(name: &str, config: &ExternalDependencySearchConfig) -> Option<PathBuf> {
+    let var_name = format!("{}_LIBDIR", name.to_uppercase());
+    if let Ok(env_incdir) = std::env::var(&var_name) {
+        Some(env_incdir.into())
+    } else {
+        config.prefixes.get(&var_name).cloned()
+    }
+}
+
+fn not_found_error_msg(name: &String) -> String {
+    let env_dir = format!("{}_DIR", &name.to_uppercase());
+    let env_inc = format!("{}_INCDIR", &name.to_uppercase());
+    let env_lib = format!("{}_LIBDIR", &name.to_uppercase());
+
+    format!(
+        r#"External dependency not found: {}.
+Consider one of the following:
+1. Set environment variables:
+   - {} for the installation prefix, or
+   - {} and {} for specific directories
+2. Add the installation prefix to the configuration:
+   {} = "/path/to/installation""#,
+        name, env_dir, env_inc, env_lib, env_dir,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::{prelude::*, TempDir};
+
+    #[tokio::test]
+    async fn test_detect_zlib_pkg_config_header() {
+        // requires zlib to be in the nativeCheckInputs or dev environment
+        let config = ExternalDependencySearchConfig::default();
+        let result = ExternalDependencyInfo::detect(
+            "zlib",
+            &ExternalDependencySpec::Header("zlib.h".into()),
+            &config,
+        );
+        assert!(matches!(result, Ok(ExternalDependencyInfo::PkgConfig(_))));
+    }
+
+    #[tokio::test]
+    async fn test_detect_zlib_pkg_config_library_libz() {
+        // requires zlib to be in the nativeCheckInputs or dev environment
+        let config = ExternalDependencySearchConfig::default();
+        let result = ExternalDependencyInfo::detect(
+            "zlib",
+            &ExternalDependencySpec::Library("libz".into()),
+            &config,
+        );
+        assert!(matches!(result, Ok(ExternalDependencyInfo::PkgConfig(_))));
+    }
+
+    #[tokio::test]
+    async fn test_detect_zlib_pkg_config_library_z() {
+        // requires zlib to be in the nativeCheckInputs or dev environment
+        let config = ExternalDependencySearchConfig::default();
+        let result = ExternalDependencyInfo::detect(
+            "zlib",
+            &ExternalDependencySpec::Library("z".into()),
+            &config,
+        );
+        assert!(matches!(result, Ok(ExternalDependencyInfo::PkgConfig(_))));
+    }
+
+    #[tokio::test]
+    async fn test_detect_zlib_pkg_config_library_zlib() {
+        // requires zlib to be in the nativeCheckInputs or dev environment
+        let config = ExternalDependencySearchConfig::default();
+        let result = ExternalDependencyInfo::detect(
+            "zlib",
+            &ExternalDependencySpec::Library("zlib".into()),
+            &config,
+        );
+        assert!(matches!(result, Ok(ExternalDependencyInfo::PkgConfig(_))));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_detect_header_prefix() {
+        let temp = TempDir::new().unwrap();
+        let prefix_dir = temp.child("usr");
+        let include_dir = prefix_dir.child("include");
+        include_dir.create_dir_all().unwrap();
+
+        let header = include_dir.child("foo.h");
+        header.touch().unwrap();
+
+        let mut config = ExternalDependencySearchConfig::default();
+        config
+            .prefixes
+            .insert("FOO_DIR".into(), prefix_dir.path().to_path_buf());
+
+        let result = ExternalDependencyInfo::fallback_detect(
+            "foo",
+            &ExternalDependencySpec::Header("foo.h".into()),
+            &config,
+        );
+
+        assert!(matches!(
+            result,
+            Ok(ExternalDependencyInfo::HeaderOnly {
+                include_dir: _,
+                prefix: _,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_detect_header_prefix_incdir() {
+        let temp = TempDir::new().unwrap();
+        let include_dir = temp.child("include");
+        include_dir.create_dir_all().unwrap();
+
+        let header = include_dir.child("foo.h");
+        header.touch().unwrap();
+
+        let mut config = ExternalDependencySearchConfig::default();
+        config
+            .prefixes
+            .insert("FOO_INCDIR".into(), include_dir.path().to_path_buf());
+
+        let result = ExternalDependencyInfo::fallback_detect(
+            "foo",
+            &ExternalDependencySpec::Header("foo.h".into()),
+            &config,
+        );
+
+        assert!(matches!(
+            result,
+            Ok(ExternalDependencyInfo::HeaderOnly {
+                include_dir: _,
+                prefix: _,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_detect_library_prefix() {
+        let temp = TempDir::new().unwrap();
+        let prefix_dir = temp.child("usr");
+        let include_dir = prefix_dir.child("include");
+        let lib_dir = prefix_dir.child("lib");
+        include_dir.create_dir_all().unwrap();
+        lib_dir.create_dir_all().unwrap();
+
+        #[cfg(target_os = "linux")]
+        let lib = lib_dir.child("libfoo.so");
+        #[cfg(target_os = "macos")]
+        let lib = lib_dir.child("libfoo.dylib");
+        #[cfg(target_family = "windows")]
+        let lib = lib_dir.child("foo.dll");
+
+        lib.touch().unwrap();
+
+        let mut config = ExternalDependencySearchConfig::default();
+        config
+            .prefixes
+            .insert("FOO_DIR".to_string(), prefix_dir.path().to_path_buf());
+
+        let result = ExternalDependencyInfo::fallback_detect(
+            "foo",
+            &ExternalDependencySpec::Library("foo".into()),
+            &config,
+        );
+
+        assert!(matches!(
+            result,
+            Ok(ExternalDependencyInfo::Library {
+                include_dir: _,
+                lib_dir: _,
+                prefix: _,
+                lib_file: _,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_detect_library_dirs() {
+        let temp = TempDir::new().unwrap();
+
+        let include_dir = temp.child("include");
+        include_dir.create_dir_all().unwrap();
+
+        let lib_dir = temp.child("lib");
+        lib_dir.create_dir_all().unwrap();
+
+        #[cfg(target_os = "linux")]
+        let lib = lib_dir.child("libfoo.so");
+        #[cfg(target_os = "macos")]
+        let lib = lib_dir.child("libfoo.dylib");
+        #[cfg(target_family = "windows")]
+        let lib = lib_dir.child("foo.dll");
+
+        lib.touch().unwrap();
+
+        let mut config = ExternalDependencySearchConfig::default();
+        config
+            .prefixes
+            .insert("FOO_INCDIR".into(), include_dir.path().to_path_buf());
+        config
+            .prefixes
+            .insert("FOO_LIBDIR".into(), lib_dir.path().to_path_buf());
+
+        let result = ExternalDependencyInfo::fallback_detect(
+            "foo",
+            &ExternalDependencySpec::Library("foo".into()),
+            &config,
+        );
+
+        assert!(matches!(
+            result,
+            Ok(ExternalDependencyInfo::Library {
+                include_dir: _,
+                lib_dir: _,
+                prefix: _,
+                lib_file: _,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_detect_search_prefixes() {
+        let temp = TempDir::new().unwrap();
+        let prefix_dir = temp.child("usr");
+        let include_dir = prefix_dir.child("include");
+        let lib_dir = prefix_dir.child("lib");
+        include_dir.create_dir_all().unwrap();
+        lib_dir.create_dir_all().unwrap();
+
+        #[cfg(target_os = "linux")]
+        let lib = lib_dir.child("libfoo.so");
+        #[cfg(target_os = "macos")]
+        let lib = lib_dir.child("libfoo.dylib");
+        #[cfg(target_family = "windows")]
+        let lib = lib_dir.child("foo.dll");
+
+        lib.touch().unwrap();
+
+        let mut config = ExternalDependencySearchConfig::default();
+        config.search_prefixes.push(prefix_dir.path().to_path_buf());
+
+        let result = ExternalDependencyInfo::fallback_detect(
+            "foo",
+            &ExternalDependencySpec::Library("foo".into()),
+            &config,
+        );
+
+        assert!(matches!(
+            result,
+            Ok(ExternalDependencyInfo::Library {
+                include_dir: _,
+                lib_dir: _,
+                prefix: _,
+                lib_file: _,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_detect_not_found() {
+        let config = ExternalDependencySearchConfig::default();
+
+        let result = ExternalDependencyInfo::fallback_detect(
+            "foo",
+            &ExternalDependencySpec::Header("foo.h".into()),
+            &config,
+        );
+
+        assert!(matches!(result, Err(ExternalDependencyError::NotFound(_))));
+    }
+}

--- a/rocks-lib/src/config/external_deps.rs
+++ b/rocks-lib/src/config/external_deps.rs
@@ -1,0 +1,91 @@
+use std::{collections::HashMap, path::PathBuf};
+
+/// Used as a fallback when searching for external dependencies if they
+/// cannot be found using pkg-config.
+#[derive(Debug, Clone)]
+pub struct ExternalDependencySearchConfig {
+    /// Patterns for binary files
+    pub bin_patterns: Vec<String>,
+    /// Patterns for header files
+    pub include_patterns: Vec<String>,
+    /// Patterns for library files
+    pub lib_patterns: Vec<String>,
+    /// Default binary subdirectory
+    pub bin_subdir: String,
+    /// Default include subdirectory
+    pub include_subdir: String,
+    /// Default library subdirectory
+    pub lib_subdir: Vec<String>,
+    /// System-wide search paths
+    pub search_prefixes: Vec<PathBuf>,
+    /// Known installation prefixes for specific dependencies.
+    /// These can also be set via environment variables.
+    pub prefixes: HashMap<String, PathBuf>,
+}
+
+impl Default for ExternalDependencySearchConfig {
+    fn default() -> Self {
+        Self {
+            bin_patterns: vec!["?".into()],
+            include_patterns: vec!["?.h".into()],
+            lib_patterns: default_lib_patterns(),
+            bin_subdir: "bin".into(),
+            include_subdir: "include".into(),
+            lib_subdir: vec!["lib".into(), "lib64".into()],
+            search_prefixes: default_prefixes(),
+            prefixes: HashMap::default(),
+        }
+    }
+}
+
+#[cfg(target_family = "unix")]
+fn default_lib_patterns() -> Vec<String> {
+    #[cfg(target_os = "macos")]
+    {
+        vec!["lib?.dylib".to_string(), "lib?.a".to_string()]
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        vec!["lib?.so".to_string(), "lib?.a".to_string()]
+    }
+}
+
+#[cfg(target_family = "windows")]
+fn default_lib_patterns() -> Vec<String> {
+    vec!["?.dll".to_string(), "?.lib".to_string()]
+}
+
+#[cfg(target_family = "unix")]
+fn default_prefixes() -> Vec<PathBuf> {
+    use std::path::PathBuf;
+
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            PathBuf::from("/usr"),
+            PathBuf::from("/usr/local"),
+            PathBuf::from("/opt/local"),
+            PathBuf::from("/opt/homebrew"),
+            PathBuf::from("/opt"),
+        ]
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        vec![
+            PathBuf::from("/usr"),
+            PathBuf::from("/usr/local"),
+            PathBuf::from("/opt/local"),
+            PathBuf::from("/opt"),
+        ]
+    }
+}
+
+#[cfg(target_family = "windows")]
+fn default_prefixes() -> Vec<PathBuf> {
+    vec![
+        PathBuf::from(r"C:\Program Files"),
+        PathBuf::from(r"C:\Program Files (x86)"),
+    ]
+}

--- a/rocks-lib/src/config/mod.rs
+++ b/rocks-lib/src/config/mod.rs
@@ -1,4 +1,5 @@
 use directories::ProjectDirs;
+use external_deps::ExternalDependencySearchConfig;
 use std::{
     collections::HashMap, env, fmt::Display, io, path::PathBuf, str::FromStr, time::Duration,
 };
@@ -12,6 +13,8 @@ use crate::{
     package::{PackageVersion, PackageVersionReq},
     project::{Project, ProjectError},
 };
+
+pub mod external_deps;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LuaVersion {
@@ -156,6 +159,7 @@ pub struct Config {
     make: String,
     cmake: String,
     variables: HashMap<String, String>,
+    external_deps: ExternalDependencySearchConfig,
 
     cache_dir: PathBuf,
     data_dir: PathBuf,
@@ -251,6 +255,10 @@ impl Config {
         &self.variables
     }
 
+    pub fn external_deps(&self) -> &ExternalDependencySearchConfig {
+        &self.external_deps
+    }
+
     pub fn cache_dir(&self) -> &PathBuf {
         &self.cache_dir
     }
@@ -291,6 +299,7 @@ pub struct ConfigBuilder {
     make: Option<String>,
     cmake: Option<String>,
     variables: Option<HashMap<String, String>>,
+    external_deps: Option<ExternalDependencySearchConfig>,
 
     cache_dir: Option<PathBuf>,
     data_dir: Option<PathBuf>,
@@ -377,6 +386,13 @@ impl ConfigBuilder {
         Self { variables, ..self }
     }
 
+    pub fn external_deps(self, external_deps: Option<ExternalDependencySearchConfig>) -> Self {
+        Self {
+            external_deps,
+            ..self
+        }
+    }
+
     pub fn cache_dir(self, cache_dir: Option<PathBuf>) -> Self {
         Self { cache_dir, ..self }
     }
@@ -441,6 +457,7 @@ impl ConfigBuilder {
             make: self.make.unwrap_or("make".into()),
             cmake: self.cmake.unwrap_or("cmake".into()),
             variables: self.variables.unwrap_or(default_variables),
+            external_deps: self.external_deps.unwrap_or_default(),
             cache_dir,
             data_dir,
         })

--- a/rocks-lib/src/rockspec/dependency.rs
+++ b/rocks-lib/src/rockspec/dependency.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::Infallible};
+use std::{collections::HashMap, convert::Infallible, path::PathBuf};
 
 use serde::Deserialize;
 
@@ -7,14 +7,14 @@ use super::{PartialOverride, PerPlatform, PlatformOverridable};
 /// Can be defined in a [platform-agnostic](https://github.com/luarocks/luarocks/wiki/platform-agnostic-external-dependencies) manner
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
-pub enum ExternalDependency {
+pub enum ExternalDependencySpec {
     /// A header file, e.g. "foo.h"
-    Header(String),
-    /// A library file, e.g. "foo.lib"
-    Library(String),
+    Header(PathBuf),
+    /// A library file, e.g. "libfoo.so"
+    Library(PathBuf),
 }
 
-impl PartialOverride for HashMap<String, ExternalDependency> {
+impl PartialOverride for HashMap<String, ExternalDependencySpec> {
     type Err = Infallible;
 
     fn apply_overrides(&self, override_map: &Self) -> Result<Self, Self::Err> {
@@ -29,7 +29,7 @@ impl PartialOverride for HashMap<String, ExternalDependency> {
     }
 }
 
-impl PlatformOverridable for HashMap<String, ExternalDependency> {
+impl PlatformOverridable for HashMap<String, ExternalDependencySpec> {
     type Err = Infallible;
 
     fn on_nil<T>() -> Result<super::PerPlatform<T>, <Self as PlatformOverridable>::Err>

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -48,7 +48,7 @@ pub struct Rockspec {
     pub supported_platforms: PlatformSupport,
     pub dependencies: PerPlatform<Vec<PackageReq>>,
     pub build_dependencies: PerPlatform<Vec<PackageReq>>,
-    pub external_dependencies: PerPlatform<HashMap<String, ExternalDependency>>,
+    pub external_dependencies: PerPlatform<HashMap<String, ExternalDependencySpec>>,
     pub test_dependencies: PerPlatform<Vec<PackageReq>>,
     pub source: PerPlatform<RockSource>,
     pub build: PerPlatform<BuildSpec>,
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(rockspec.description, expected_description);
         assert_eq!(
             *rockspec.external_dependencies.default.get("FOO").unwrap(),
-            ExternalDependency::Library("foo".into())
+            ExternalDependencySpec::Library("foo".into())
         );
 
         let rockspec_content = "
@@ -438,7 +438,7 @@ mod tests {
         let busted = RemotePackage::parse("busted".into(), "2.2.0".into()).unwrap();
         assert_eq!(
             *rockspec.external_dependencies.default.get("FOO").unwrap(),
-            ExternalDependency::Header("foo.h".into())
+            ExternalDependencySpec::Header("foo.h".into())
         );
         assert!(rockspec
             .test_dependencies
@@ -799,7 +799,7 @@ mod tests {
         let rockspec = Rockspec::new(&rockspec_content).unwrap();
         assert_eq!(
             *rockspec.external_dependencies.default.get("FOO").unwrap(),
-            ExternalDependency::Library("foo".into())
+            ExternalDependencySpec::Library("foo".into())
         );
         let per_platform = rockspec.external_dependencies.per_platform;
         assert_eq!(
@@ -807,35 +807,35 @@ mod tests {
                 .get(&PlatformIdentifier::Windows)
                 .and_then(|it| it.get("FOO"))
                 .unwrap(),
-            ExternalDependency::Library("foo.dll".into())
+            ExternalDependencySpec::Library("foo.dll".into())
         );
         assert_eq!(
             *per_platform
                 .get(&PlatformIdentifier::Unix)
                 .and_then(|it| it.get("FOO"))
                 .unwrap(),
-            ExternalDependency::Library("foo".into())
+            ExternalDependencySpec::Library("foo".into())
         );
         assert_eq!(
             *per_platform
                 .get(&PlatformIdentifier::Unix)
                 .and_then(|it| it.get("BAR"))
                 .unwrap(),
-            ExternalDependency::Header("bar.h".into())
+            ExternalDependencySpec::Header("bar.h".into())
         );
         assert_eq!(
             *per_platform
                 .get(&PlatformIdentifier::Linux)
                 .and_then(|it| it.get("BAR"))
                 .unwrap(),
-            ExternalDependency::Header("bar.h".into())
+            ExternalDependencySpec::Header("bar.h".into())
         );
         assert_eq!(
             *per_platform
                 .get(&PlatformIdentifier::Linux)
                 .and_then(|it| it.get("FOO"))
                 .unwrap(),
-            ExternalDependency::Library("foo.so".into())
+            ExternalDependencySpec::Library("foo.so".into())
         );
         let rockspec_content = "
         rockspec_format = '1.0'\n


### PR DESCRIPTION
Stacked on #267 

Closes #174.

- Uses pkg-config and then falls back to a built-in mechanism based on the LuaRocks implementation.