### PR TITLE
feat: don't reinstall dependencies that are already installed

### DIFF
--- a/rocks-lib/src/lockfile/mod.rs
+++ b/rocks-lib/src/lockfile/mod.rs
@@ -485,6 +485,26 @@ impl Lockfile {
 
         Ok(())
     }
+
+    pub(crate) fn list(&self) -> HashMap<PackageName, Vec<LocalPackage>> {
+        self.rocks()
+            .values()
+            .cloned()
+            .map(|locked_rock| (locked_rock.name().clone(), locked_rock))
+            .into_group_map()
+    }
+
+    pub(crate) fn has_rock(&self, req: &PackageReq) -> Option<LocalPackage> {
+        self.list()
+            .get(req.name())
+            .map(|packages| {
+                packages
+                    .iter()
+                    .rev()
+                    .find(|package| req.version_req().matches(package.version()))
+            })?
+            .cloned()
+    }
 }
 
 impl Drop for Lockfile {

--- a/rocks-lib/src/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks_installation.rs
@@ -155,6 +155,7 @@ impl LuaRocksInstallation {
             build_dependencies,
             pin,
             Arc::new(manifest),
+            Arc::new(lockfile.clone()),
             &self.config,
             progress_arc,
         )

--- a/rocks-lib/src/operations/install.rs
+++ b/rocks-lib/src/operations/install.rs
@@ -83,6 +83,7 @@ async fn install_impl(
         packages,
         pin,
         Arc::new(manifest),
+        Arc::new(lockfile.clone()),
         config,
         progress_arc.clone(),
     )

--- a/rocks-lib/src/operations/resolve.rs
+++ b/rocks-lib/src/operations/resolve.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     build::BuildBehaviour,
     config::Config,
-    lockfile::{LocalPackageId, LocalPackageSpec, LockConstraint, PinnedState},
+    lockfile::{LocalPackageId, LocalPackageSpec, LockConstraint, Lockfile, PinnedState},
     manifest::Manifest,
     package::{PackageReq, PackageVersionReq},
     progress::{MultiProgress, Progress},
@@ -31,60 +31,77 @@ pub(crate) async fn get_all_dependencies(
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
     manifest: Arc<Manifest>,
+    lockfile: Arc<Lockfile>,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackageId>, SearchAndDownloadError> {
-    join_all(packages.into_iter().map(|(build_behaviour, package)| {
-        let config = config.clone();
-        let tx = tx.clone();
-        let manifest = Arc::clone(&manifest);
-        let progress = Arc::clone(&progress);
+    join_all(
+        packages
+            .into_iter()
+            // Exclude packages that are already installed
+            .filter(|(build_behaviour, package)| {
+                build_behaviour == &BuildBehaviour::Force || lockfile.has_rock(package).is_none()
+            })
+            .map(|(build_behaviour, package)| {
+                let config = config.clone();
+                let tx = tx.clone();
+                let manifest = Arc::clone(&manifest);
+                let progress = Arc::clone(&progress);
+                let lockfile = Arc::clone(&lockfile);
 
-        tokio::spawn(async move {
-            let bar = progress.map(|p| p.new_bar());
+                tokio::spawn(async move {
+                    let bar = progress.map(|p| p.new_bar());
 
-            let rockspec = download_rockspec(&package, &manifest, &config, &bar)
-                .await
-                .unwrap();
+                    let rockspec = download_rockspec(&package, &manifest, &config, &bar)
+                        .await
+                        .unwrap();
 
-            let constraint =
-                if *package.version_req() == PackageVersionReq::SemVer(VersionReq::STAR) {
-                    LockConstraint::Unconstrained
-                } else {
-                    LockConstraint::Constrained(package.version_req().clone())
-                };
+                    let constraint =
+                        if *package.version_req() == PackageVersionReq::SemVer(VersionReq::STAR) {
+                            LockConstraint::Unconstrained
+                        } else {
+                            LockConstraint::Constrained(package.version_req().clone())
+                        };
 
-            let dependencies = rockspec
-                .dependencies
-                .current_platform()
-                .iter()
-                .filter(|dep| !dep.name().eq(&"lua".into()))
-                .map(|dep| (build_behaviour, dep.clone()))
-                .collect_vec();
+                    let dependencies = rockspec
+                        .dependencies
+                        .current_platform()
+                        .iter()
+                        .filter(|dep| !dep.name().eq(&"lua".into()))
+                        .map(|dep| (build_behaviour, dep.clone()))
+                        .collect_vec();
 
-            let dependencies =
-                get_all_dependencies(tx.clone(), dependencies, pin, manifest, &config, progress)
+                    let dependencies = get_all_dependencies(
+                        tx.clone(),
+                        dependencies,
+                        pin,
+                        manifest,
+                        lockfile,
+                        &config,
+                        progress,
+                    )
                     .await?;
 
-            let local_spec = LocalPackageSpec::new(
-                &rockspec.package,
-                &rockspec.version,
-                constraint,
-                dependencies,
-                &pin,
-            );
+                    let local_spec = LocalPackageSpec::new(
+                        &rockspec.package,
+                        &rockspec.version,
+                        constraint,
+                        dependencies,
+                        &pin,
+                    );
 
-            let install_spec = PackageInstallSpec {
-                build_behaviour,
-                spec: local_spec.clone(),
-                rockspec,
-            };
+                    let install_spec = PackageInstallSpec {
+                        build_behaviour,
+                        spec: local_spec.clone(),
+                        rockspec,
+                    };
 
-            tx.send(install_spec).unwrap();
+                    tx.send(install_spec).unwrap();
 
-            Ok::<_, SearchAndDownloadError>(local_spec.id())
-        })
-    }))
+                    Ok::<_, SearchAndDownloadError>(local_spec.id())
+                })
+            }),
+    )
     .await
     .into_iter()
     .flatten()

--- a/rocks-lib/src/tree/list.rs
+++ b/rocks-lib/src/tree/list.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashMap, io};
 
-use itertools::Itertools;
-
 use crate::{lockfile::LocalPackage, package::PackageName};
 
 use super::Tree;
@@ -13,13 +11,7 @@ use super::Tree;
 
 impl Tree {
     pub fn list(&self) -> io::Result<HashMap<PackageName, Vec<LocalPackage>>> {
-        Ok(self
-            .lockfile()?
-            .rocks()
-            .values()
-            .cloned()
-            .map(|locked_rock| (locked_rock.name().clone(), locked_rock))
-            .into_group_map())
+        Ok(self.lockfile()?.list())
     }
 
     pub fn as_rock_list(&self) -> io::Result<Vec<LocalPackage>> {

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -131,16 +131,7 @@ impl Tree {
     }
 
     pub fn has_rock(&self, req: &PackageReq) -> Option<LocalPackage> {
-        self.list()
-            .ok()?
-            .get(req.name())
-            .map(|packages| {
-                packages
-                    .iter()
-                    .rev()
-                    .find(|package| req.version_req().matches(package.version()))
-            })?
-            .cloned()
+        self.lockfile().ok()?.has_rock(req)
     }
 
     pub fn has_rock_and<F>(&self, req: &PackageReq, filter: F) -> Option<LocalPackage>


### PR DESCRIPTION
- In `resolve::get_all_dependencies`, we filter out dependencies that are already installed, as long as the `build_behaviour` is `NoForce`.
- We set the build behaviour to `NoForce` for dependencies.
  This means that we don't reinstall dependencies when reinstalling a rock. (Is this desirable behaviour? :thinking:).