### PR TITLE
refactor: `Manifest` type with `server_url`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
 [alias]
 tt = "nextest run --tests --no-fail-fast" # All
 tl = "nextest run --lib --no-fail-fast" # Lib only
+xtask = "run --package xtask --"
+rocks = "run --package rocks --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.18",
@@ -432,14 +432,23 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.3",
+ "clap_lex 0.7.4",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
+dependencies = [
+ "clap 4.5.23",
 ]
 
 [[package]]
@@ -478,9 +487,19 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbae9cbfdc5d4fa8711c09bd7b83f644cb48281ac35bf97af3e47b0675864bdf"
+dependencies = [
+ "clap 4.5.23",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2863,7 +2882,7 @@ dependencies = [
 name = "rocks"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.21",
+ "clap 4.5.23",
  "eyre",
  "git-url-parse",
  "git2",
@@ -2897,7 +2916,7 @@ dependencies = [
  "async-recursion",
  "bytes",
  "cc",
- "clap 4.5.21",
+ "clap 4.5.23",
  "dir-diff",
  "directories",
  "flate2",
@@ -2946,6 +2965,12 @@ dependencies = [
  "which 7.0.0",
  "zip",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rustc-demangle"
@@ -4585,6 +4610,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap 4.5.23",
+ "clap_complete",
+ "clap_mangen",
+ "rocks",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "rocks-lib",
     "rocks-bin",
+    "xtask",
     # "rocks-lua",
 ]
 resolver = "2"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -14,6 +14,7 @@
 
         nativeBuildInputs = [
           pkg-config
+          installShellFiles
         ];
 
         buildInputs =
@@ -34,7 +35,13 @@
           cacert
           cargo-nextest
           zlib # used for checking external dependencies
+          lua
         ];
+
+        postBuild = ''
+          cargo xtask dist-man
+          cargo xtask dist-completions
+        '';
 
         preCheck = ''
           export HOME=$(realpath .)
@@ -47,6 +54,11 @@
           runHook postCheck
         '';
 
+        postInstall = ''
+          installManPage target/dist/rocks.1
+          installShellCompletion target/dist/rocks.{bash,fish} --zsh target/dist/_rocks
+        '';
+
         env = {
           # disable vendored packages
           LIBGIT2_NO_VENDOR = 1;
@@ -54,6 +66,8 @@
         };
 
         inherit buildType;
+
+        meta.mainProgram = "rocks";
       };
 in {
   rocks = mk-rocks {};

--- a/rocks-bin/src/build.rs
+++ b/rocks-bin/src/build.rs
@@ -9,7 +9,7 @@ use rocks_lib::{
     build::BuildBehaviour,
     config::Config,
     lockfile::{LockConstraint::Unconstrained, PinnedState},
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::{PackageName, PackageReq},
     progress::MultiProgress,
     rockspec::Rockspec,
@@ -69,7 +69,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
     let lua_version = rockspec.lua_version_from_config(&config)?;
 
     let tree = Tree::new(config.tree().clone(), lua_version)?;
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     let build_behaviour = match tree.has_rock_and(
         &PackageReq::new(

--- a/rocks-bin/src/download.rs
+++ b/rocks-bin/src/download.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::Config,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::PackageReq,
     progress::{MultiProgress, Progress},
 };
@@ -13,7 +13,7 @@ pub struct Download {
 }
 
 pub async fn download(dl_data: Download, config: Config) -> Result<()> {
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
 

--- a/rocks-bin/src/fetch.rs
+++ b/rocks-bin/src/fetch.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use eyre::Result;
 use rocks_lib::{
     config::Config,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     progress::{MultiProgress, Progress},
 };
 
@@ -13,7 +13,7 @@ pub async fn fetch_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let package_req = data.package_req;
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
     let rockspec =
         rocks_lib::operations::download_rockspec(&package_req, &manifest, &config, &bar).await?;
 

--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     operations::download_rockspec,
     package::PackageReq,
     progress::{MultiProgress, Progress},
@@ -17,7 +17,7 @@ pub struct Info {
 pub async fn info(data: Info, config: Config) -> Result<()> {
     // TODO(vhyrro): Add `Tree::from(&Config)`
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());

--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -5,7 +5,7 @@ use rocks_lib::{
     build::BuildBehaviour,
     config::{Config, LuaVersion},
     lockfile::PinnedState,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::PackageReq,
     progress::MultiProgress,
     tree::Tree,
@@ -54,7 +54,7 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
         })
         .collect_vec();
 
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
     rocks_lib::operations::install(packages, pin, &manifest, &config, MultiProgress::new_arc())

--- a/rocks-bin/src/lib.rs
+++ b/rocks-bin/src/lib.rs
@@ -1,33 +1,48 @@
-use std::{path::PathBuf, time::Duration};
+use crate::project::NewProject;
+use std::path::PathBuf;
 
+use build::Build;
 use clap::{Parser, Subcommand};
-use rocks::{
-    build::{self, Build},
-    debug::Debug,
-    download::{self, Download},
-    fetch, format,
-    info::{self, Info},
-    install::{self, Install},
-    install_lua,
-    list::{self, ListCmd},
-    outdated::{self, Outdated},
-    path::{self, Path},
-    pin::{self, ChangePin},
-    project::{self, NewProject},
-    purge,
-    remove::{self, Remove},
-    run::{self, Run},
-    run_lua::{self, RunLua},
-    search::{self, Search},
-    test::{self, Test},
-    unpack,
-    update::{self, Update},
-    upload::{self, Upload},
-};
-use rocks_lib::{
-    config::{ConfigBuilder, LuaVersion},
-    lockfile::PinnedState::{Pinned, Unpinned},
-};
+use debug::Debug;
+use download::Download;
+use info::Info;
+use install::Install;
+use list::ListCmd;
+use outdated::Outdated;
+use path::Path;
+use pin::ChangePin;
+use remove::Remove;
+use rocks_lib::config::LuaVersion;
+use run::Run;
+use run_lua::RunLua;
+use search::Search;
+use test::Test;
+use update::Update;
+use upload::Upload;
+
+pub mod build;
+pub mod debug;
+pub mod download;
+pub mod fetch;
+pub mod format;
+pub mod info;
+pub mod install;
+pub mod install_lua;
+pub mod list;
+pub mod outdated;
+pub mod path;
+pub mod pin;
+pub mod project;
+pub mod purge;
+pub mod remove;
+pub mod run;
+pub mod run_lua;
+pub mod search;
+pub mod test;
+pub mod unpack;
+pub mod update;
+pub mod upload;
+pub mod utils;
 
 /// A fast and efficient Lua package manager.
 #[derive(Parser)]
@@ -154,69 +169,4 @@ pub enum Commands {
     Upload(Upload),
     /// [UNIMPLEMENTED] Tell which file corresponds to a given module name.
     Which,
-}
-
-#[tokio::main(flavor = "multi_thread")]
-async fn main() {
-    let cli = Cli::parse();
-
-    let config = ConfigBuilder::new()
-        .dev(Some(cli.dev))
-        .lua_dir(cli.lua_dir)
-        .lua_version(cli.lua_version)
-        .namespace(cli.namespace)
-        .only_server(cli.only_server)
-        .only_sources(cli.only_sources)
-        .server(cli.server)
-        .tree(cli.tree)
-        .timeout(
-            cli.timeout
-                .map(|duration| Duration::from_secs(duration as u64)),
-        )
-        .no_project(Some(cli.no_project))
-        .verbose(Some(cli.verbose))
-        .build()
-        .unwrap();
-
-    match cli.command {
-        Commands::Search(search_data) => search::search(search_data, config).await.unwrap(),
-        Commands::Download(download_data) => {
-            download::download(download_data, config).await.unwrap()
-        }
-        Commands::Debug(debug) => match debug {
-            Debug::FetchRemote(unpack_data) => {
-                fetch::fetch_remote(unpack_data, config).await.unwrap()
-            }
-            Debug::Unpack(unpack_data) => unpack::unpack(unpack_data).await.unwrap(),
-            Debug::UnpackRemote(unpack_data) => {
-                unpack::unpack_remote(unpack_data, config).await.unwrap()
-            }
-            Debug::Project => project::debug_project().unwrap(),
-        },
-        Commands::New(project_data) => project::write_project_rockspec(project_data).await.unwrap(),
-        Commands::Build(build_data) => build::build(build_data, config).await.unwrap(),
-        Commands::List(list_data) => list::list_installed(list_data, config).unwrap(),
-        Commands::Lua(run_lua) => run_lua::run_lua(run_lua, config).await.unwrap(),
-        Commands::Install(install_data) => install::install(install_data, config).await.unwrap(),
-        Commands::Outdated(outdated) => outdated::outdated(outdated, config).await.unwrap(),
-        Commands::InstallLua => install_lua::install_lua(config).await.unwrap(),
-        Commands::Fmt => format::format().unwrap(),
-        Commands::Purge => purge::purge(config).await.unwrap(),
-        Commands::Remove(remove_args) => remove::remove(remove_args, config).await.unwrap(),
-        Commands::Run(run_args) => run::run(run_args, config).await.unwrap(),
-        Commands::Test(test) => test::test(test, config).await.unwrap(),
-        Commands::Update(_update_args) => update::update(config).await.unwrap(),
-        Commands::Info(info_data) => info::info(info_data, config).await.unwrap(),
-        Commands::Path(path_data) => path::path(path_data, config).await.unwrap(),
-        Commands::Pin(pin_data) => pin::set_pinned_state(pin_data, config, Pinned).unwrap(),
-        Commands::Unpin(pin_data) => pin::set_pinned_state(pin_data, config, Unpinned).unwrap(),
-        Commands::Upload(upload_data) => upload::upload(upload_data, config).await.unwrap(),
-        Commands::Add => unimplemented!(),
-        Commands::Config => unimplemented!(),
-        Commands::Doc => unimplemented!(),
-        Commands::Lint => unimplemented!(),
-        Commands::Pack => unimplemented!(),
-        Commands::Uninstall => unimplemented!(),
-        Commands::Which => unimplemented!(),
-    }
 }

--- a/rocks-bin/src/outdated.rs
+++ b/rocks-bin/src/outdated.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use itertools::Itertools;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     progress::{MultiProgress, ProgressBar},
     tree::Tree,
 };
@@ -25,7 +25,7 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
 
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
 
-    let metadata = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     // NOTE: This will display all installed versions and each possible upgrade.
     // However, this should also take into account dependency constraints made by other rocks.
@@ -36,7 +36,7 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
         .iter()
         .filter_map(|rock| {
             rock.to_package()
-                .has_update(&metadata)
+                .has_update(manifest.metadata())
                 .expect("TODO")
                 .map(|version| (rock, version))
         })

--- a/rocks-bin/src/pin.rs
+++ b/rocks-bin/src/pin.rs
@@ -3,7 +3,7 @@ use eyre::eyre;
 use eyre::Result;
 use rocks_lib::lockfile::PinnedState;
 use rocks_lib::operations;
-use rocks_lib::package::RemotePackage;
+use rocks_lib::package::PackageSpec;
 use rocks_lib::{
     config::{Config, LuaVersion},
     tree::Tree,
@@ -11,7 +11,7 @@ use rocks_lib::{
 
 #[derive(Args)]
 pub struct ChangePin {
-    package: RemotePackage,
+    package: PackageSpec,
 }
 
 pub fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState) -> Result<()> {

--- a/rocks-bin/src/remove.rs
+++ b/rocks-bin/src/remove.rs
@@ -2,8 +2,8 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    manifest::ManifestMetadata,
-    package::{PackageName, PackageVersion, RemotePackage},
+    manifest::Manifest,
+    package::{PackageName, PackageSpec, PackageVersion},
     progress::{MultiProgress, Progress},
     tree::Tree,
 };
@@ -17,17 +17,20 @@ pub struct Remove {
 }
 
 pub async fn remove(remove_args: Remove, config: Config) -> Result<()> {
-    let metadata = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     let target_version = remove_args
         .version
-        .or(metadata.latest_version(&remove_args.name).cloned())
+        .or(manifest
+            .metadata()
+            .latest_version(&remove_args.name)
+            .cloned())
         .unwrap();
 
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
 
     match tree.has_rock(
-        &RemotePackage::new(remove_args.name.clone(), target_version.clone()).into_package_req(),
+        &PackageSpec::new(remove_args.name.clone(), target_version.clone()).into_package_req(),
     ) {
         Some(package) => Ok(rocks_lib::operations::remove(
             package,

--- a/rocks-bin/src/search.rs
+++ b/rocks-bin/src/search.rs
@@ -7,7 +7,7 @@ use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
 
 use rocks_lib::{
     config::Config,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::{PackageName, PackageReq, PackageVersion},
     progress::{MultiProgress, ProgressBar},
 };
@@ -30,11 +30,12 @@ pub async fn search(data: Search, config: Config) -> Result<()> {
 
     let formatting = TreeFormatting::dir_tree(FormatCharacters::box_chars());
 
-    let metadata = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     let lua_package_req = data.lua_package_req;
 
-    let rock_to_version_map: HashMap<&PackageName, Vec<&PackageVersion>> = metadata
+    let rock_to_version_map: HashMap<&PackageName, Vec<&PackageVersion>> = manifest
+        .metadata()
         .repository
         .iter()
         .filter_map(|(name, elements)| {

--- a/rocks-bin/src/test.rs
+++ b/rocks-bin/src/test.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use eyre::{OptionExt, Result};
 use rocks_lib::{
     config::Config,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     operations::{ensure_busted, ensure_dependencies, run_tests, TestEnv},
     progress::MultiProgress,
     project::Project,
@@ -26,7 +26,7 @@ pub async fn test(test: Test, config: Config) -> Result<()> {
         Ok(lua_version) => Ok(lua_version),
         Err(_) => rockspec.test_lua_version().ok_or_eyre("lua version not set! Please provide a version through `--lua-version <ver>` or add it to your rockspec's dependencies"),
     }?;
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
     let test_config = config.with_lua_version(lua_version);
     let tree = Tree::new(
         test_config.tree().clone(),

--- a/rocks-bin/src/unpack.rs
+++ b/rocks-bin/src/unpack.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::Config,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::PackageReq,
     progress::{MultiProgress, Progress},
 };
@@ -49,7 +49,7 @@ and type `rocks make` to build.",
 
 pub async fn unpack_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let package_req = data.package_req;
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
     let rock =

--- a/rocks-bin/src/update.rs
+++ b/rocks-bin/src/update.rs
@@ -3,9 +3,7 @@ use eyre::Result;
 use rocks_lib::config::LuaVersion;
 use rocks_lib::lockfile::PinnedState;
 use rocks_lib::progress::{MultiProgress, ProgressBar};
-use rocks_lib::{
-    config::Config, manifest::ManifestMetadata, operations, package::PackageReq, tree::Tree,
-};
+use rocks_lib::{config::Config, manifest::Manifest, operations, package::PackageReq, tree::Tree};
 
 #[derive(Args)]
 pub struct Update {}
@@ -18,7 +16,7 @@ pub async fn update(config: Config) -> Result<()> {
 
     let lockfile = tree.lockfile()?;
     let rocks = lockfile.rocks();
-    let manifest = ManifestMetadata::from_config(&config).await?;
+    let manifest = Manifest::from_config(config.server(), &config).await?;
 
     for package in rocks.values() {
         if package.pinned() == PinnedState::Unpinned {

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     lockfile::{LocalPackage, LocalPackageHashes, LockConstraint, PinnedState},
     lua_installation::LuaInstallation,
     operations::{self, FetchSrcRockError},
-    package::RemotePackage,
+    package::PackageSpec,
     progress::{Progress, ProgressBar},
     rockspec::{Build as _, BuildBackendSpec, LuaVersionError, Rockspec},
     tree::{RockLayout, Tree},
@@ -212,7 +212,7 @@ pub async fn build(
     // Install the source in order to build.
     let rock_source = rockspec.source.current_platform();
     if let Err(err) = operations::fetch_src(temp_dir.path(), rock_source, progress).await {
-        let package = RemotePackage::new(rockspec.package.clone(), rockspec.version.clone());
+        let package = PackageSpec::new(rockspec.package.clone(), rockspec.version.clone());
         progress.map(|p| {
             p.println(format!(
                 "⚠️ WARNING: Failed to fetch source for {}: {}",
@@ -243,7 +243,7 @@ pub async fn build(
     }
 
     let mut package = LocalPackage::from(
-        &RemotePackage::new(rockspec.package.clone(), rockspec.version.clone()),
+        &PackageSpec::new(rockspec.package.clone(), rockspec.version.clone()),
         constraint,
         hashes,
     );

--- a/rocks-lib/src/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks_installation.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{Config, LuaVersion, LuaVersionUnset},
     lockfile::{LocalPackage, LocalPackageId, LockConstraint, PinnedState},
     lua_installation::LuaInstallation,
-    manifest::{ManifestError, ManifestMetadata},
+    manifest::{Manifest, ManifestError},
     operations::{get_all_dependencies, SearchAndDownloadError},
     package::PackageReq,
     path::Paths,
@@ -129,7 +129,7 @@ impl LuaRocksInstallation {
     ) -> Result<(), InstallBuildDependenciesError> {
         let progress = Arc::clone(&progress_arc);
         let mut lockfile = self.tree.lockfile()?;
-        let manifest = ManifestMetadata::from_config(&self.config).await?;
+        let manifest = Manifest::from_config(self.config.server(), &self.config).await?;
         let build_dependencies = match rockspec.rockspec_format {
             Some(RockspecFormat::_1_0 | RockspecFormat::_2_0) => {
                 // XXX: rockspec formats < 3.0 don't support `build_dependencies`,

--- a/rocks-lib/src/operations/fetch.rs
+++ b/rocks-lib/src/operations/fetch.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 use crate::config::Config;
 use crate::operations;
+use crate::package::PackageSpec;
 use crate::package::RemotePackage;
 use crate::progress::Progress;
 use crate::progress::ProgressBar;
@@ -134,12 +135,13 @@ pub enum FetchSrcRockError {
 }
 
 pub async fn fetch_src_rock(
-    package: &RemotePackage,
+    package: &PackageSpec,
     dest_dir: &Path,
     config: &Config,
     progress: &Progress<ProgressBar>,
 ) -> Result<(), FetchSrcRockError> {
-    let src_rock = operations::download_src_rock(package, config, progress).await?;
+    let remote_package = RemotePackage::new(package.clone(), config.server().clone());
+    let src_rock = operations::download_src_rock(&remote_package, progress).await?;
     let cursor = Cursor::new(src_rock.bytes);
     let mime_type = infer::get(cursor.get_ref()).map(|file_type| file_type.mime_type());
     unpack(

--- a/rocks-lib/src/operations/install.rs
+++ b/rocks-lib/src/operations/install.rs
@@ -7,7 +7,7 @@ use crate::{
     luarocks_installation::{
         InstallBuildDependenciesError, LuaRocksError, LuaRocksInstallError, LuaRocksInstallation,
     },
-    manifest::{ManifestError, ManifestMetadata},
+    manifest::{Manifest, ManifestError},
     package::{PackageName, PackageReq},
     progress::{MultiProgress, Progress, ProgressBar},
     rockspec::{BuildBackendSpec, LuaVersionError},
@@ -45,7 +45,7 @@ pub enum InstallError {
 pub async fn install(
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
-    manifest: &ManifestMetadata,
+    manifest: &Manifest,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackage>, InstallError>
@@ -70,7 +70,7 @@ where
 async fn install_impl(
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
-    manifest: ManifestMetadata,
+    manifest: Manifest,
     config: &Config,
     lockfile: &mut Lockfile,
     progress_arc: Arc<Progress<MultiProgress>>,

--- a/rocks-lib/src/operations/pin.rs
+++ b/rocks-lib/src/operations/pin.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
     lockfile::{LocalPackage, PinnedState},
-    package::RemotePackage,
+    package::PackageSpec,
     tree::Tree,
 };
 
@@ -17,12 +17,12 @@ pub enum PinError {
     #[error("rock {rock} is already {}pinned!", if *.pin_state == PinnedState::Unpinned { "un" } else { "" })]
     PinStateUnchanged {
         pin_state: PinnedState,
-        rock: RemotePackage,
+        rock: PackageSpec,
     },
     #[error("cannot change pin state of {rock}, since a second version of {rock} is already installed with `pin: {}`", .pin_state.as_bool())]
     PinStateConflict {
         pin_state: PinnedState,
-        rock: RemotePackage,
+        rock: PackageSpec,
     },
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/rocks-lib/src/operations/resolve.rs
+++ b/rocks-lib/src/operations/resolve.rs
@@ -10,7 +10,7 @@ use crate::{
     build::BuildBehaviour,
     config::Config,
     lockfile::{LocalPackageId, LocalPackageSpec, LockConstraint, PinnedState},
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::{PackageReq, PackageVersionReq},
     progress::{MultiProgress, Progress},
     rockspec::Rockspec,
@@ -30,7 +30,7 @@ pub(crate) async fn get_all_dependencies(
     tx: UnboundedSender<PackageInstallSpec>,
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
-    manifest: Arc<ManifestMetadata>,
+    manifest: Arc<Manifest>,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackageId>, SearchAndDownloadError> {

--- a/rocks-lib/src/operations/run.rs
+++ b/rocks-lib/src/operations/run.rs
@@ -4,7 +4,7 @@ use crate::{
     build::BuildBehaviour,
     config::{Config, LuaVersion, LuaVersionUnset},
     lockfile::PinnedState,
-    manifest::{ManifestError, ManifestMetadata},
+    manifest::{Manifest, ManifestError},
     package::{PackageReq, PackageVersionReqError},
     path::Paths,
     progress::MultiProgress,
@@ -59,7 +59,7 @@ pub enum InstallCmdError {
 /// This defaults to the local project tree if cwd is a project root.
 pub async fn install_command(command: &str, config: &Config) -> Result<(), InstallCmdError> {
     let package_req = PackageReq::new(command.into(), None)?;
-    let manifest = ManifestMetadata::from_config(config).await?;
+    let manifest = Manifest::from_config(config.server(), config).await?;
     super::install(
         vec![(BuildBehaviour::NoForce, package_req)],
         PinnedState::Unpinned,

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -4,7 +4,7 @@ use crate::{
     build::BuildBehaviour,
     config::Config,
     lockfile::PinnedState,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     package::{PackageName, PackageReq, PackageVersionReqError},
     path::Paths,
     progress::{MultiProgress, Progress},
@@ -101,7 +101,7 @@ pub enum InstallTestDependenciesError {
 /// This defaults to the local project tree if cwd is a project root.
 pub async fn ensure_busted(
     tree: &Tree,
-    manifest: &ManifestMetadata,
+    manifest: &Manifest,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), InstallTestDependenciesError> {
@@ -126,7 +126,7 @@ pub async fn ensure_busted(
 pub async fn ensure_dependencies(
     rockspec: &Rockspec,
     tree: &Tree,
-    manifest: &ManifestMetadata,
+    manifest: &Manifest,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), InstallTestDependenciesError> {

--- a/rocks-lib/src/operations/update.rs
+++ b/rocks-lib/src/operations/update.rs
@@ -6,8 +6,8 @@ use crate::{
     build::BuildBehaviour,
     config::Config,
     lockfile::{LocalPackage, PinnedState},
-    manifest::ManifestMetadata,
-    package::{PackageReq, RemotePackage, RockConstraintUnsatisfied},
+    manifest::Manifest,
+    package::{PackageReq, PackageSpec, RockConstraintUnsatisfied},
     progress::{MultiProgress, Progress, ProgressBar},
 };
 
@@ -21,20 +21,20 @@ pub enum UpdateError {
     Install {
         #[source]
         error: InstallError,
-        package: RemotePackage,
+        package: PackageSpec,
     },
     #[error("failed to remove old rock ({package}) after update: {error}")]
     Remove {
         #[source]
         error: RemoveError,
-        package: RemotePackage,
+        package: PackageSpec,
     },
 }
 
 pub async fn update(
     package: LocalPackage,
     constraint: PackageReq,
-    manifest: &ManifestMetadata,
+    manifest: &Manifest,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), UpdateError> {

--- a/rocks-lib/src/package/outdated.rs
+++ b/rocks-lib/src/package/outdated.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 use thiserror::Error;
 
-use crate::manifest::ManifestMetadata;
+use crate::manifest::{Manifest, ManifestMetadata};
 
-use super::{version::PackageVersion, PackageName, PackageReq, PackageVersionReq, RemotePackage};
+use super::{version::PackageVersion, PackageName, PackageReq, PackageSpec, PackageVersionReq};
 
 #[derive(Error, Debug)]
 #[error("rock {0} not found")]
@@ -17,14 +17,14 @@ pub struct RockConstraintUnsatisfied {
     constraint: PackageVersionReq,
 }
 
-impl RemotePackage {
+impl PackageSpec {
     /// Tries to find a newer version of a given rock.
     /// Returns the latest version if found.
     pub fn has_update(
         &self,
-        manifest: &ManifestMetadata,
+        metadata: &ManifestMetadata,
     ) -> Result<Option<PackageVersion>, RockNotFound> {
-        let latest_version = manifest
+        let latest_version = metadata
             .latest_version(&self.name)
             .ok_or_else(|| RockNotFound(self.name.clone()))?;
 
@@ -40,15 +40,15 @@ impl RemotePackage {
     pub fn has_update_with(
         &self,
         constraint: &PackageReq,
-        manifest: &ManifestMetadata,
+        manifest: &Manifest,
     ) -> Result<Option<PackageVersion>, RockConstraintUnsatisfied> {
-        let latest_version =
-            manifest
-                .latest_match(constraint)
-                .ok_or_else(|| RockConstraintUnsatisfied {
-                    name: self.name.clone(),
-                    constraint: constraint.version_req.clone(),
-                })?;
+        let latest_version = manifest
+            .metadata()
+            .latest_match(constraint)
+            .ok_or_else(|| RockConstraintUnsatisfied {
+                name: self.name.clone(),
+                constraint: constraint.version_req.clone(),
+            })?;
 
         if self.version < latest_version.version {
             Ok(Some(latest_version.version))
@@ -58,7 +58,7 @@ impl RemotePackage {
     }
 }
 
-impl Display for RemotePackage {
+impl Display for PackageSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(format!("{} {}", self.name, self.version).as_str())
     }
@@ -68,20 +68,20 @@ impl Display for RemotePackage {
 mod test {
     use std::path::PathBuf;
 
-    use crate::{manifest::ManifestMetadata, package::RemotePackage};
+    use crate::{manifest::ManifestMetadata, package::PackageSpec};
 
     #[test]
     fn rock_has_update() {
         let test_manifest_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/manifest-5.1");
-        let manifest = String::from_utf8(std::fs::read(&test_manifest_path).unwrap()).unwrap();
-        let manifest = ManifestMetadata::new(&manifest).unwrap();
+        let content = String::from_utf8(std::fs::read(&test_manifest_path).unwrap()).unwrap();
+        let metadata = ManifestMetadata::new(&content).unwrap();
 
         let test_package =
-            RemotePackage::parse("lua-cjson".to_string(), "2.0.0".to_string()).unwrap();
+            PackageSpec::parse("lua-cjson".to_string(), "2.0.0".to_string()).unwrap();
 
         assert_eq!(
-            test_package.has_update(&manifest).unwrap(),
+            test_package.has_update(&metadata).unwrap(),
             Some("2.1.0-1".parse().unwrap())
         );
     }

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -275,7 +275,7 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use crate::package::RemotePackage;
+    use crate::package::PackageSpec;
     use crate::rockspec::PlatformIdentifier;
 
     use super::*;
@@ -423,19 +423,19 @@ mod tests {
         assert!(!rockspec
             .supported_platforms
             .is_supported(&PlatformIdentifier::Windows));
-        let neorg = RemotePackage::parse("neorg".into(), "6.0.0".into()).unwrap();
+        let neorg = PackageSpec::parse("neorg".into(), "6.0.0".into()).unwrap();
         assert!(rockspec
             .dependencies
             .default
             .into_iter()
             .any(|dep| dep.matches(&neorg)));
-        let foo = RemotePackage::parse("foo".into(), "1.0.0".into()).unwrap();
+        let foo = PackageSpec::parse("foo".into(), "1.0.0".into()).unwrap();
         assert!(rockspec
             .build_dependencies
             .default
             .into_iter()
             .any(|dep| dep.matches(&foo)));
-        let busted = RemotePackage::parse("busted".into(), "2.2.0".into()).unwrap();
+        let busted = PackageSpec::parse("busted".into(), "2.2.0".into()).unwrap();
         assert_eq!(
             *rockspec.external_dependencies.default.get("FOO").unwrap(),
             ExternalDependencySpec::Header("foo.h".into())
@@ -736,9 +736,9 @@ mod tests {
         "
         .to_string();
         let rockspec = Rockspec::new(&rockspec_content).unwrap();
-        let neorg_override = RemotePackage::parse("neorg".into(), "5.0.0".into()).unwrap();
-        let toml_edit = RemotePackage::parse("toml-edit".into(), "1.0.0".into()).unwrap();
-        let toml = RemotePackage::parse("toml".into(), "1.0.0".into()).unwrap();
+        let neorg_override = PackageSpec::parse("neorg".into(), "5.0.0".into()).unwrap();
+        let toml_edit = PackageSpec::parse("toml-edit".into(), "1.0.0".into()).unwrap();
+        let toml = PackageSpec::parse("toml".into(), "1.0.0".into()).unwrap();
         assert_eq!(rockspec.dependencies.default.len(), 2);
         let per_platform = &rockspec.dependencies.per_platform;
         assert_eq!(

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -239,7 +239,7 @@ mod tests {
         build::variables::HasVariables as _,
         config::LuaVersion,
         lockfile::{LocalPackage, LocalPackageHashes, LockConstraint},
-        package::{PackageName, PackageVersion, RemotePackage},
+        package::{PackageName, PackageSpec, PackageVersion},
         tree::RockLayout,
     };
 
@@ -266,7 +266,7 @@ mod tests {
         };
 
         let package = LocalPackage::from(
-            &RemotePackage::parse("neorg".into(), "8.0.0-1".into()).unwrap(),
+            &PackageSpec::parse("neorg".into(), "8.0.0-1".into()).unwrap(),
             LockConstraint::Unconstrained,
             mock_hashes.clone(),
         );
@@ -289,7 +289,7 @@ mod tests {
         );
 
         let package = LocalPackage::from(
-            &RemotePackage::parse("lua-cjson".into(), "2.1.0-1".into()).unwrap(),
+            &PackageSpec::parse("lua-cjson".into(), "2.1.0-1".into()).unwrap(),
             LockConstraint::Unconstrained,
             mock_hashes.clone(),
         );
@@ -364,7 +364,7 @@ mod tests {
 
         let neorg = tree
             .rock(&LocalPackage::from(
-                &RemotePackage::parse("neorg".into(), "8.0.0-1-1".into()).unwrap(),
+                &PackageSpec::parse("neorg".into(), "8.0.0-1-1".into()).unwrap(),
                 LockConstraint::Unconstrained,
                 mock_hashes.clone(),
             ))

--- a/rocks-lib/tests/test.rs
+++ b/rocks-lib/tests/test.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use rocks_lib::{
     config::ConfigBuilder,
-    manifest::ManifestMetadata,
+    manifest::Manifest,
     operations::{ensure_busted, run_tests, TestEnv},
     progress::MultiProgress,
     project::Project,
@@ -18,7 +18,9 @@ async fn run_busted_test() {
     let _ = std::fs::remove_dir_all(&tree_root);
     let config = ConfigBuilder::new().tree(Some(tree_root)).build().unwrap();
     let tree = Tree::new(config.tree().clone(), config.lua_version().unwrap().clone()).unwrap();
-    let manifest = ManifestMetadata::from_config(&config).await.unwrap();
+    let manifest = Manifest::from_config(&config.server(), &config)
+        .await
+        .unwrap();
     ensure_busted(&tree, &manifest, &config, MultiProgress::new_arc())
         .await
         .unwrap();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { version = "4.5.23", features = ["derive"] }
+clap_complete = "4.5.40"
+clap_mangen = "0.2.24"
+
+[dependencies.rocks]
+path = "../rocks-bin"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,113 @@
+use std::{
+    env,
+    fs::{self, File},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{generate_to, Shell};
+use clap_mangen::Man;
+use rocks::Cli;
+
+type DynError = Box<dyn std::error::Error>;
+
+fn main() {
+    if let Err(e) = try_main() {
+        eprintln!("{}", e);
+        std::process::exit(-1);
+    }
+}
+
+fn try_main() -> Result<(), DynError> {
+    let task = env::args().nth(1);
+    match task.as_deref() {
+        Some("dist") => dist()?,
+        Some("dist-man") => dist_man()?,
+        Some("dist-completions") => dist_completions()?,
+        _ => print_help(),
+    }
+    Ok(())
+}
+
+fn print_help() {
+    eprintln!(
+        "Tasks:
+
+dist                builds application, shell completions and man pages
+dist-man            builds man pages
+dist-completions    builds shell completions
+"
+    )
+}
+
+fn dist() -> Result<(), DynError> {
+    let _ = fs::remove_dir_all(dist_dir());
+    fs::create_dir_all(dist_dir())?;
+
+    let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let status = Command::new(cargo)
+        .current_dir(project_root())
+        .args(["build", "--release"])
+        .status()?;
+
+    if !status.success() {
+        Err("cargo build failed")?;
+    }
+
+    let dst = project_root().join("target/release/rocks");
+
+    fs::copy(&dst, dist_dir().join("rocks"))?;
+
+    if Command::new("strip")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .status()
+        .is_ok()
+    {
+        eprintln!("stripping the binary");
+        let status = Command::new("strip").arg(&dst).status()?;
+        if !status.success() {
+            Err("strip failed")?;
+        }
+    } else {
+        eprintln!("no `strip` utility found")
+    }
+    dist_man()?;
+    dist_completions()
+}
+
+fn dist_man() -> Result<(), DynError> {
+    fs::create_dir_all(dist_dir())?;
+
+    let cmd = &mut Cli::command();
+
+    Man::new(cmd.clone())
+        .render(&mut File::create(dist_dir().join("rocks.1")).unwrap())
+        .unwrap();
+    Ok(())
+}
+
+fn dist_completions() -> Result<(), DynError> {
+    fs::create_dir_all(dist_dir())?;
+
+    let cmd = &mut Cli::command();
+
+    for shell in Shell::value_variants() {
+        generate_to(*shell, cmd, "rocks", dist_dir()).unwrap();
+    }
+
+    Ok(())
+}
+
+fn project_root() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf()
+}
+
+fn dist_dir() -> PathBuf {
+    project_root().join("target/dist")
+}


### PR DESCRIPTION
Stacked on #279.

If we want to implement #159, we will need to search more than one manifest and a search result needs to contain the `server_url` info.

This PR prepares for #159, as follows:

- Split `RemotePackage` into `PackageSpec` and `RemotePackage` types (the latter contains the URL)
- Introduce a `Manifest` type, which also contains the URL and the `ManifestMetadata`

In a follow-up, we can implement searching for multiple manifests.