### PR TITLE
fix!: prepend paths instead of appending them

### DIFF
--- a/rocks-bin/src/run.rs
+++ b/rocks-bin/src/run.rs
@@ -31,7 +31,7 @@ pub async fn run(run: Run, config: Config) -> Result<()> {
     let paths = Paths::from_tree(tree)?;
     unsafe {
         // safe as long as this is single-threaded
-        env::set_var("PATH", paths.path_appended().joined());
+        env::set_var("PATH", paths.path_prepended().joined());
     }
     if which(&run.command).is_err() {
         match project {

--- a/rocks-bin/src/run_lua.rs
+++ b/rocks-bin/src/run_lua.rs
@@ -58,7 +58,7 @@ pub async fn run_lua(run_lua: RunLua, config: Config) -> Result<()> {
     let paths = Paths::from_tree(tree)?;
     let status = match Command::new(&lua_cmd)
         .args(run_lua.args.unwrap_or_default())
-        .env("PATH", paths.path_appended().joined())
+        .env("PATH", paths.path_prepended().joined())
         .env("LUA_PATH", paths.package_path().joined())
         .env("LUA_CPATH", paths.package_cpath().joined())
         .status()

--- a/rocks-lib/src/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks_installation.rs
@@ -265,7 +265,7 @@ variables = {{
         let output = Command::new("luarocks")
             .current_dir(cwd)
             .args(args)
-            .env("PATH", luarocks_paths.path_appended().joined())
+            .env("PATH", luarocks_paths.path_prepended().joined())
             .env("LUA_PATH", luarocks_paths.package_path().joined())
             .env("LUA_CPATH", luarocks_paths.package_cpath().joined())
             .env("HOME", temp_dir.into_path())

--- a/rocks-lib/src/operations/run.rs
+++ b/rocks-lib/src/operations/run.rs
@@ -32,7 +32,7 @@ pub async fn run(command: &str, args: Vec<String>, config: Config) -> Result<(),
     let paths = Paths::from_tree(tree)?;
     let status = match Command::new(command)
         .args(args)
-        .env("PATH", paths.path_appended().joined())
+        .env("PATH", paths.path_prepended().joined())
         .env("LUA_PATH", paths.package_path().joined())
         .env("LUA_CPATH", paths.package_cpath().joined())
         .status()

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -57,7 +57,7 @@ where
     let mut command = command
         .current_dir(project.root())
         .args(test_args)
-        .env("PATH", paths.path_appended().joined())
+        .env("PATH", paths.path_prepended().joined())
         .env("LUA_PATH", paths.package_path().joined())
         .env("LUA_CPATH", paths.package_cpath().joined());
     if let TestEnv::Pure = env {

--- a/rocks-lib/src/path.rs
+++ b/rocks-lib/src/path.rs
@@ -55,10 +55,10 @@ impl Paths {
         &self.bin
     }
 
-    /// Get the `$PATH`, appended to the existing `$PATH` environment.
-    pub fn path_appended(&self) -> BinPath {
+    /// Get the `$PATH`, prepended to the existing `$PATH` environment.
+    pub fn path_prepended(&self) -> BinPath {
         let mut path = BinPath::from_env();
-        path.append(self.path());
+        path.prepend(self.path());
         path
     }
 }
@@ -67,8 +67,10 @@ impl Paths {
 pub struct PackagePath(Vec<PathBuf>);
 
 impl PackagePath {
-    pub fn append(&mut self, other: &Self) {
-        self.0.extend(other.0.to_owned())
+    pub fn prepend(&mut self, other: &Self) {
+        let mut new_vec = other.0.to_owned();
+        new_vec.append(&mut self.0);
+        self.0 = new_vec;
     }
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -108,8 +110,10 @@ impl BinPath {
     pub fn from_env() -> Self {
         Self::from_str(env::var("PATH").unwrap_or_default().as_str()).unwrap_or_default()
     }
-    pub fn append(&mut self, other: &Self) {
-        self.0.extend(other.0.to_owned())
+    pub fn prepend(&mut self, other: &Self) {
+        let mut new_vec = other.0.to_owned();
+        new_vec.append(&mut self.0);
+        self.0 = new_vec;
     }
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()


### PR DESCRIPTION
Closes #281.

Also changes the `--append` flag for the `rocks path` command to `--prepend`.