### PR TITLE
feat!: support installing from multiple servers

### DIFF
--- a/rocks-bin/src/build.rs
+++ b/rocks-bin/src/build.rs
@@ -9,9 +9,9 @@ use rocks_lib::{
     build::BuildBehaviour,
     config::Config,
     lockfile::{LockConstraint::Unconstrained, PinnedState},
-    manifest::Manifest,
     package::{PackageName, PackageReq},
     progress::MultiProgress,
+    remote_package_db::RemotePackageDB,
     rockspec::Rockspec,
     tree::Tree,
 };
@@ -69,7 +69,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
     let lua_version = rockspec.lua_version_from_config(&config)?;
 
     let tree = Tree::new(config.tree().clone(), lua_version)?;
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
 
     let build_behaviour = match tree.has_rock_and(
         &PackageReq::new(
@@ -114,7 +114,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
     rocks_lib::operations::install(
         dependencies_to_install,
         pin,
-        &manifest,
+        &package_db,
         &config,
         progress_arc,
     )

--- a/rocks-bin/src/download.rs
+++ b/rocks-bin/src/download.rs
@@ -2,9 +2,9 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::Config,
-    manifest::Manifest,
     package::PackageReq,
     progress::{MultiProgress, Progress},
+    remote_package_db::RemotePackageDB,
 };
 
 #[derive(Args)]
@@ -13,18 +13,13 @@ pub struct Download {
 }
 
 pub async fn download(dl_data: Download, config: Config) -> Result<()> {
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
 
-    let rock = rocks_lib::operations::download_to_file(
-        &dl_data.package_req,
-        None,
-        &manifest,
-        &config,
-        &bar,
-    )
-    .await?;
+    let rock =
+        rocks_lib::operations::download_to_file(&dl_data.package_req, None, &package_db, &bar)
+            .await?;
 
     bar.map(|b| {
         b.finish_with_message(format!(

--- a/rocks-bin/src/fetch.rs
+++ b/rocks-bin/src/fetch.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use eyre::Result;
 use rocks_lib::{
     config::Config,
-    manifest::Manifest,
     progress::{MultiProgress, Progress},
+    remote_package_db::RemotePackageDB,
 };
 
 use crate::unpack::UnpackRemote;
@@ -13,9 +13,9 @@ pub async fn fetch_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let package_req = data.package_req;
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
     let rockspec =
-        rocks_lib::operations::download_rockspec(&package_req, &manifest, &config, &bar).await?;
+        rocks_lib::operations::download_rockspec(&package_req, &package_db, &bar).await?;
 
     let destination = data
         .path

--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -2,10 +2,10 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    manifest::Manifest,
     operations::download_rockspec,
     package::PackageReq,
     progress::{MultiProgress, Progress},
+    remote_package_db::RemotePackageDB,
     tree::Tree,
 };
 
@@ -17,12 +17,12 @@ pub struct Info {
 pub async fn info(data: Info, config: Config) -> Result<()> {
     // TODO(vhyrro): Add `Tree::from(&Config)`
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
 
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
 
-    let rockspec = download_rockspec(&data.package, &manifest, &config, &bar).await?;
+    let rockspec = download_rockspec(&data.package, &package_db, &bar).await?;
 
     bar.map(|b| b.finish_and_clear());
 

--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -5,9 +5,9 @@ use rocks_lib::{
     build::BuildBehaviour,
     config::{Config, LuaVersion},
     lockfile::PinnedState,
-    manifest::Manifest,
     package::PackageReq,
     progress::MultiProgress,
+    remote_package_db::RemotePackageDB,
     tree::Tree,
 };
 
@@ -54,11 +54,17 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
         })
         .collect_vec();
 
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
-    rocks_lib::operations::install(packages, pin, &manifest, &config, MultiProgress::new_arc())
-        .await?;
+    rocks_lib::operations::install(
+        packages,
+        pin,
+        &package_db,
+        &config,
+        MultiProgress::new_arc(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -43,10 +43,10 @@ pub struct Cli {
     #[arg(long, value_name = "server")]
     pub server: Option<String>,
 
-    /// Fetch rocks/rockspecs from this server only (overrides
-    /// any entries in the config file).
-    #[arg(long, value_name = "server")]
-    pub only_server: Option<String>,
+    /// Fetch rocks/rockspecs from this server in addition to the main server
+    /// (overrides any entries in the config file).
+    #[arg(long, value_name = "extra-server")]
+    pub extra_servers: Option<Vec<String>>,
 
     /// Restrict downloads to paths matching the given URL.
     #[arg(long, value_name = "url")]
@@ -165,7 +165,7 @@ async fn main() {
         .lua_dir(cli.lua_dir)
         .lua_version(cli.lua_version)
         .namespace(cli.namespace)
-        .only_server(cli.only_server)
+        .extra_servers(cli.extra_servers)
         .only_sources(cli.only_sources)
         .server(cli.server)
         .tree(cli.tree)

--- a/rocks-bin/src/outdated.rs
+++ b/rocks-bin/src/outdated.rs
@@ -5,8 +5,8 @@ use eyre::Result;
 use itertools::Itertools;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    manifest::Manifest,
     progress::{MultiProgress, ProgressBar},
+    remote_package_db::RemotePackageDB,
     tree::Tree,
 };
 use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
@@ -25,7 +25,7 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
 
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
 
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
 
     // NOTE: This will display all installed versions and each possible upgrade.
     // However, this should also take into account dependency constraints made by other rocks.
@@ -36,7 +36,7 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
         .iter()
         .filter_map(|rock| {
             rock.to_package()
-                .has_update(manifest.metadata())
+                .has_update(&package_db)
                 .expect("TODO")
                 .map(|version| (rock, version))
         })

--- a/rocks-bin/src/remove.rs
+++ b/rocks-bin/src/remove.rs
@@ -2,9 +2,9 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::{Config, LuaVersion},
-    manifest::Manifest,
     package::{PackageName, PackageSpec, PackageVersion},
     progress::{MultiProgress, Progress},
+    remote_package_db::RemotePackageDB,
     tree::Tree,
 };
 
@@ -17,14 +17,11 @@ pub struct Remove {
 }
 
 pub async fn remove(remove_args: Remove, config: Config) -> Result<()> {
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
 
     let target_version = remove_args
         .version
-        .or(manifest
-            .metadata()
-            .latest_version(&remove_args.name)
-            .cloned())
+        .or(package_db.latest_version(&remove_args.name).cloned())
         .unwrap();
 
     let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;

--- a/rocks-bin/src/test.rs
+++ b/rocks-bin/src/test.rs
@@ -2,10 +2,10 @@ use clap::Args;
 use eyre::{OptionExt, Result};
 use rocks_lib::{
     config::Config,
-    manifest::Manifest,
     operations::{ensure_busted, ensure_dependencies, run_tests, TestEnv},
     progress::MultiProgress,
     project::Project,
+    remote_package_db::RemotePackageDB,
     tree::Tree,
 };
 
@@ -26,7 +26,7 @@ pub async fn test(test: Test, config: Config) -> Result<()> {
         Ok(lua_version) => Ok(lua_version),
         Err(_) => rockspec.test_lua_version().ok_or_eyre("lua version not set! Please provide a version through `--lua-version <ver>` or add it to your rockspec's dependencies"),
     }?;
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
     let test_config = config.with_lua_version(lua_version);
     let tree = Tree::new(
         test_config.tree().clone(),
@@ -34,8 +34,8 @@ pub async fn test(test: Test, config: Config) -> Result<()> {
     )?;
     let progress = MultiProgress::new_arc();
     // TODO(#204): Only ensure busted if running with busted (e.g. a .busted directory exists)
-    ensure_busted(&tree, &manifest, &test_config, progress.clone()).await?;
-    ensure_dependencies(rockspec, &tree, &manifest, &test_config, progress).await?;
+    ensure_busted(&tree, &package_db, &test_config, progress.clone()).await?;
+    ensure_dependencies(rockspec, &tree, &package_db, &test_config, progress).await?;
     let test_args = test.test_args.unwrap_or_default();
     let test_env = if test.impure {
         TestEnv::Impure

--- a/rocks-bin/src/unpack.rs
+++ b/rocks-bin/src/unpack.rs
@@ -4,9 +4,9 @@ use clap::Args;
 use eyre::Result;
 use rocks_lib::{
     config::Config,
-    manifest::Manifest,
     package::PackageReq,
     progress::{MultiProgress, Progress},
+    remote_package_db::RemotePackageDB,
 };
 
 #[derive(Args)]
@@ -49,12 +49,11 @@ and type `rocks make` to build.",
 
 pub async fn unpack_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let package_req = data.package_req;
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
-    let rock =
-        rocks_lib::operations::search_and_download_src_rock(&package_req, &manifest, &config, &bar)
-            .await?;
+    let rock = rocks_lib::operations::search_and_download_src_rock(&package_req, &package_db, &bar)
+        .await?;
     let cursor = Cursor::new(rock.bytes);
 
     let destination = data

--- a/rocks-bin/src/update.rs
+++ b/rocks-bin/src/update.rs
@@ -3,7 +3,8 @@ use eyre::Result;
 use rocks_lib::config::LuaVersion;
 use rocks_lib::lockfile::PinnedState;
 use rocks_lib::progress::{MultiProgress, ProgressBar};
-use rocks_lib::{config::Config, manifest::Manifest, operations, package::PackageReq, tree::Tree};
+use rocks_lib::remote_package_db::RemotePackageDB;
+use rocks_lib::{config::Config, operations, package::PackageReq, tree::Tree};
 
 #[derive(Args)]
 pub struct Update {}
@@ -16,7 +17,7 @@ pub async fn update(config: Config) -> Result<()> {
 
     let lockfile = tree.lockfile()?;
     let rocks = lockfile.rocks();
-    let manifest = Manifest::from_config(config.server(), &config).await?;
+    let package_db = RemotePackageDB::from_config(&config).await?;
 
     for package in rocks.values() {
         if package.pinned() == PinnedState::Unpinned {
@@ -26,7 +27,7 @@ pub async fn update(config: Config) -> Result<()> {
                     package.name().to_string(),
                     package.constraint().to_string_opt(),
                 )?,
-                &manifest,
+                &package_db,
                 &config,
                 progress.clone(),
             )

--- a/rocks-lib/src/config/mod.rs
+++ b/rocks-lib/src/config/mod.rs
@@ -146,7 +146,7 @@ pub struct NoValidHomeDirectory;
 pub struct Config {
     enable_development_rockspecs: bool,
     server: String,
-    only_server: Option<String>,
+    extra_servers: Vec<String>,
     only_sources: Option<String>,
     namespace: String,
     lua_dir: PathBuf,
@@ -201,8 +201,8 @@ impl Config {
         &self.server
     }
 
-    pub fn only_server(&self) -> Option<&String> {
-        self.only_server.as_ref()
+    pub fn extra_servers(&self) -> &Vec<String> {
+        self.extra_servers.as_ref()
     }
 
     pub fn only_sources(&self) -> Option<&String> {
@@ -286,7 +286,7 @@ pub enum ConfigError {
 pub struct ConfigBuilder {
     enable_development_rockspecs: Option<bool>,
     server: Option<String>,
-    only_server: Option<String>,
+    extra_servers: Option<Vec<String>>,
     only_sources: Option<String>,
     namespace: Option<String>,
     lua_dir: Option<PathBuf>,
@@ -321,10 +321,9 @@ impl ConfigBuilder {
         Self { server, ..self }
     }
 
-    pub fn only_server(self, server: Option<String>) -> Self {
+    pub fn extra_servers(self, extra_servers: Option<Vec<String>>) -> Self {
         Self {
-            only_server: server.clone(),
-            server,
+            extra_servers,
             ..self
         }
     }
@@ -433,7 +432,7 @@ impl ConfigBuilder {
             server: self
                 .server
                 .unwrap_or_else(|| "https://luarocks.org/".to_string()),
-            only_server: self.only_server,
+            extra_servers: self.extra_servers.unwrap_or_default(),
             only_sources: self.only_sources,
             namespace: self.namespace.unwrap_or_default(),
             lua_dir: self.lua_dir.unwrap_or_else(|| data_dir.join("lua")),

--- a/rocks-lib/src/lib.rs
+++ b/rocks-lib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod package;
 pub mod path;
 pub mod progress;
 pub mod project;
+pub mod remote_package_db;
 pub mod rockspec;
 pub mod tree;
 pub mod upload;

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -4,11 +4,11 @@ use crate::{
     build::BuildBehaviour,
     config::Config,
     lockfile::PinnedState,
-    manifest::Manifest,
     package::{PackageName, PackageReq, PackageVersionReqError},
     path::Paths,
     progress::{MultiProgress, Progress},
     project::Project,
+    remote_package_db::RemotePackageDB,
     rockspec::Rockspec,
     tree::Tree,
 };
@@ -101,7 +101,7 @@ pub enum InstallTestDependenciesError {
 /// This defaults to the local project tree if cwd is a project root.
 pub async fn ensure_busted(
     tree: &Tree,
-    manifest: &Manifest,
+    package_db: &RemotePackageDB,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), InstallTestDependenciesError> {
@@ -111,7 +111,7 @@ pub async fn ensure_busted(
         install(
             vec![(BuildBehaviour::NoForce, busted_req)],
             PinnedState::Unpinned,
-            manifest,
+            package_db,
             config,
             progress,
         )
@@ -126,7 +126,7 @@ pub async fn ensure_busted(
 pub async fn ensure_dependencies(
     rockspec: &Rockspec,
     tree: &Tree,
-    manifest: &Manifest,
+    package_db: &RemotePackageDB,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), InstallTestDependenciesError> {
@@ -149,7 +149,7 @@ pub async fn ensure_dependencies(
     install(
         dependencies,
         PinnedState::Unpinned,
-        manifest,
+        package_db,
         config,
         progress,
     )

--- a/rocks-lib/src/operations/update.rs
+++ b/rocks-lib/src/operations/update.rs
@@ -6,9 +6,9 @@ use crate::{
     build::BuildBehaviour,
     config::Config,
     lockfile::{LocalPackage, PinnedState},
-    manifest::Manifest,
     package::{PackageReq, PackageSpec, RockConstraintUnsatisfied},
     progress::{MultiProgress, Progress, ProgressBar},
+    remote_package_db::RemotePackageDB,
 };
 
 use super::{install, remove, InstallError, RemoveError};
@@ -34,7 +34,7 @@ pub enum UpdateError {
 pub async fn update(
     package: LocalPackage,
     constraint: PackageReq,
-    manifest: &Manifest,
+    package_db: &RemotePackageDB,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), UpdateError> {
@@ -42,7 +42,7 @@ pub async fn update(
 
     let latest_version = package
         .to_package()
-        .has_update_with(&constraint, manifest)?;
+        .has_update_with(&constraint, package_db)?;
 
     if latest_version.is_some() && package.pinned() == PinnedState::Unpinned {
         // TODO(vhyrro): There's a slight dissonance in the API here.
@@ -54,7 +54,7 @@ pub async fn update(
         install(
             vec![(BuildBehaviour::NoForce, constraint)],
             PinnedState::Unpinned,
-            manifest,
+            package_db,
             config,
             progress,
         )

--- a/rocks-lib/src/remote_package_db/mod.rs
+++ b/rocks-lib/src/remote_package_db/mod.rs
@@ -1,0 +1,103 @@
+use crate::{
+    config::Config,
+    manifest::{Manifest, ManifestError},
+    package::{PackageName, PackageReq, PackageSpec, PackageVersion, RemotePackage},
+    progress::{Progress, ProgressBar},
+};
+use itertools::Itertools as _;
+use thiserror::Error;
+
+#[derive(Clone)]
+pub struct RemotePackageDB(Vec<Manifest>);
+
+#[derive(Error, Debug)]
+pub enum RemotePackageDBError {
+    #[error(transparent)]
+    ManifestError(#[from] ManifestError),
+}
+
+#[derive(Error, Debug)]
+pub enum SearchError {
+    #[error(transparent)]
+    Mlua(#[from] mlua::Error),
+    #[error("no rock that matches '{0}' found")]
+    RockNotFound(PackageReq),
+    #[error("error when pulling manifest: {0}")]
+    Manifest(#[from] ManifestError),
+}
+
+impl RemotePackageDB {
+    pub async fn from_config(config: &Config) -> Result<Self, RemotePackageDBError> {
+        let mut manifests = Vec::new();
+        for server in config.extra_servers() {
+            let manifest = Manifest::from_config(server, config).await?;
+            manifests.push(manifest);
+        }
+        manifests.push(Manifest::from_config(config.server(), config).await?);
+        Ok(Self(manifests))
+    }
+
+    /// Find a package that matches the requirement
+    pub(crate) fn find(
+        &self,
+        package_req: &PackageReq,
+        progress: &Progress<ProgressBar>,
+    ) -> Result<RemotePackage, SearchError> {
+        let result = self.0.iter().find_map(|manifest| {
+            progress.map(|p| p.set_message(format!("🔎 Searching {}", &manifest.server_url())));
+            manifest.search(package_req)
+        });
+        match result {
+            Some(package) => Ok(package),
+            None => Err(SearchError::RockNotFound(package_req.clone())),
+        }
+    }
+
+    /// Search for all packages that match the requirement
+    pub fn search(&self, package_req: &PackageReq) -> Vec<(&PackageName, Vec<&PackageVersion>)> {
+        self.0
+            .iter()
+            .flat_map(|manifest| {
+                manifest
+                    .metadata()
+                    .repository
+                    .iter()
+                    .filter_map(|(name, elements)| {
+                        if name.to_string().contains(&package_req.name().to_string()) {
+                            Some((
+                                name,
+                                elements
+                                    .keys()
+                                    .filter(|version| package_req.version_req().matches(version))
+                                    .sorted_by(|a, b| Ord::cmp(b, a))
+                                    .collect_vec(),
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+            })
+            .collect()
+    }
+
+    pub fn latest_version(&self, rock_name: &PackageName) -> Option<&PackageVersion> {
+        self.0
+            .iter()
+            .filter_map(|manifest| manifest.metadata().latest_version(rock_name))
+            .sorted()
+            .last()
+    }
+
+    pub fn latest_match(&self, package_req: &PackageReq) -> Option<PackageSpec> {
+        self.0
+            .iter()
+            .filter_map(|manifest| manifest.metadata().latest_match(package_req))
+            .last()
+    }
+}
+
+impl From<Manifest> for RemotePackageDB {
+    fn from(manifest: Manifest) -> Self {
+        RemotePackageDB(vec![manifest])
+    }
+}

--- a/rocks-lib/tests/test.rs
+++ b/rocks-lib/tests/test.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use rocks_lib::{
     config::ConfigBuilder,
-    manifest::Manifest,
     operations::{ensure_busted, run_tests, TestEnv},
     progress::MultiProgress,
     project::Project,
+    remote_package_db::RemotePackageDB,
     tree::Tree,
 };
 
@@ -18,10 +18,8 @@ async fn run_busted_test() {
     let _ = std::fs::remove_dir_all(&tree_root);
     let config = ConfigBuilder::new().tree(Some(tree_root)).build().unwrap();
     let tree = Tree::new(config.tree().clone(), config.lua_version().unwrap().clone()).unwrap();
-    let manifest = Manifest::from_config(&config.server(), &config)
-        .await
-        .unwrap();
-    ensure_busted(&tree, &manifest, &config, MultiProgress::new_arc())
+    let package_db = RemotePackageDB::from_config(&config).await.unwrap();
+    ensure_busted(&tree, &package_db, &config, MultiProgress::new_arc())
         .await
         .unwrap();
     run_tests(project, Vec::new(), TestEnv::Pure, config)


### PR DESCRIPTION
In preparation for #159.
This PR makes the `Manifest` and `ManifestMetadata` types `pub(crate)`. `rocks-lib` now only exposes the `RemotePackageDB` type (which could one day be a client to a non-luarocks server).