### PR TITLE
feat: `rocks check`

### DIFF
--- a/rocks-bin/src/check.rs
+++ b/rocks-bin/src/check.rs
@@ -1,0 +1,42 @@
+use eyre::{OptionExt, Result};
+use rocks_lib::{
+    build::BuildBehaviour,
+    config::{Config, LuaVersion},
+    lockfile::PinnedState::Pinned,
+    operations::{self, install},
+    progress::MultiProgress,
+    project::Project,
+    remote_package_db::RemotePackageDB,
+};
+
+pub async fn check(config: Config) -> Result<()> {
+    let project = Project::current()?.ok_or_eyre("Not in a project!")?;
+
+    let db = RemotePackageDB::from_config(&config).await?;
+
+    install(
+        vec![(BuildBehaviour::NoForce, "luacheck".parse()?)],
+        Pinned,
+        &db,
+        &config,
+        MultiProgress::new_arc(),
+    )
+    .await?;
+
+    operations::run(
+        "luacheck",
+        vec![
+            project.root().to_string_lossy().into(),
+            "--exclude-files".into(),
+            project
+                .tree(LuaVersion::from(&config)?)?
+                .root()
+                .to_string_lossy()
+                .to_string(),
+        ],
+        config,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/rocks-bin/src/lib.rs
+++ b/rocks-bin/src/lib.rs
@@ -21,6 +21,7 @@ use update::Update;
 use upload::Upload;
 
 pub mod build;
+pub mod check;
 pub mod debug;
 pub mod download;
 pub mod fetch;
@@ -110,6 +111,8 @@ pub enum Commands {
     Add,
     /// Build/compile a rock.
     Build(Build),
+    /// Runs `luacheck` in the current project.
+    Check,
     /// [UNIMPLEMENTED] Query information about Rocks's configuration.
     Config,
     /// Various debugging utilities.

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, time::Duration};
 use clap::{Parser, Subcommand};
 use rocks::{
     build::{self, Build},
+    check,
     debug::Debug,
     download::{self, Download},
     fetch, format,
@@ -95,6 +96,8 @@ pub enum Commands {
     Add,
     /// Build/compile a rock.
     Build(Build),
+    /// Runs `luacheck` in the current project.
+    Check,
     /// [UNIMPLEMENTED] Query information about Rocks's configuration.
     Config,
     /// Various debugging utilities.
@@ -211,6 +214,7 @@ async fn main() {
         Commands::Pin(pin_data) => pin::set_pinned_state(pin_data, config, Pinned).unwrap(),
         Commands::Unpin(pin_data) => pin::set_pinned_state(pin_data, config, Unpinned).unwrap(),
         Commands::Upload(upload_data) => upload::upload(upload_data, config).await.unwrap(),
+        Commands::Check => check::check(config).await.unwrap(),
         Commands::Add => unimplemented!(),
         Commands::Config => unimplemented!(),
         Commands::Doc => unimplemented!(),

--- a/rocks-lib/src/project/mod.rs
+++ b/rocks-lib/src/project/mod.rs
@@ -71,7 +71,7 @@ impl Project {
     }
 
     pub fn tree(&self, lua_version: LuaVersion) -> io::Result<Tree> {
-        Tree::new(self.root.clone(), lua_version)
+        Tree::new(self.root.join(".rocks"), lua_version)
     }
 }
 


### PR DESCRIPTION
Adds a simple implementation of `rocks check`, which ensures `luacheck` is installed and runs it for the whole source directory of a given project.

Similarly to `rocks fmt`, we'll want to expand this to take in a path as an argument for finer control.
I don't believe we should let the user control `luacheck` with flags, that should be up to the luacheckrc file.