### PR TITLE
feat!(rocks-bin/build): project lockfiles

### DIFF
--- a/rocks-bin/src/install_rockspec.rs
+++ b/rocks-bin/src/install_rockspec.rs
@@ -1,6 +1,6 @@
-use eyre::{Context, OptionExt};
+use eyre::{eyre, Context};
 use itertools::Itertools;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use clap::Args;
 use eyre::Result;
@@ -12,35 +12,36 @@ use rocks_lib::{
     package::PackageName,
     progress::MultiProgress,
     project::Project,
-    remote_package_db::RemotePackageDB,
+    rockspec::Rockspec,
+    tree::Tree,
 };
 
 #[derive(Args, Default)]
-pub struct Build {
-    /// Whether to pin the dependencies.
+pub struct InstallRockspec {
+    /// The path to the RockSpec file to install
+    rockspec_path: PathBuf,
+
+    /// Whether to pin the installed package and dependencies.
     #[arg(long)]
     pin: bool,
-
-    /// Ignore the project's existing lockfile.
-    #[arg(long)]
-    ignore_lockfile: bool,
-
-    /// Do not create a lockfile.
-    #[arg(long)]
-    no_lock: bool,
 }
 
-pub async fn build(data: Build, config: Config) -> Result<()> {
-    let project = Project::current()?.ok_or_eyre("Not in a project!")?;
+pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<()> {
     let pin = PinnedState::from(data.pin);
-    let package_db = match project.lockfile()? {
-        None => RemotePackageDB::from_config(&config).await?,
-        Some(_) if data.ignore_lockfile => RemotePackageDB::from_config(&config).await?,
-        Some(lockfile) => lockfile.into(),
-    };
-    let rockspec = project.new_local_rockspec();
+    let project_opt = Project::current()?;
+    let path = data.rockspec_path;
+
+    if path
+        .extension()
+        .map(|ext| ext != "rockspec")
+        .unwrap_or(true)
+    {
+        return Err(eyre!("Provided path is not a valid rockspec!"));
+    }
+    let content = std::fs::read_to_string(path)?;
+    let rockspec = Rockspec::new(&content)?;
     let lua_version = rockspec.lua_version_from_config(&config)?;
-    let tree = project.tree(lua_version)?;
+    let tree = Tree::new(config.tree().clone(), lua_version)?;
 
     // Ensure all dependencies are installed first
     let dependencies = rockspec
@@ -57,21 +58,20 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
         .into_iter()
         .filter(|req| {
             tree.match_rocks(req)
-                .is_ok_and(|rock_match| !rock_match.is_found())
+                .is_ok_and(|rock_match| rock_match.is_found())
         })
         .map(|dep| (BuildBehaviour::NoForce, dep.to_owned()));
 
     Install::new(&config)
         .packages(dependencies_to_install)
         .pin(pin)
-        .package_db(package_db)
         .progress(progress_arc)
         .install()
         .await?;
 
-    if !data.no_lock {
+    if let Some(project) = project_opt {
         std::fs::copy(tree.lockfile_path(), project.lockfile_path())
-            .wrap_err("error copying the project lockfile")?;
+            .wrap_err("error creating project lockfile.")?;
     }
 
     build::Build::new(&rockspec, &config, &progress.map(|p| p.new_bar()))

--- a/rocks-bin/src/lib.rs
+++ b/rocks-bin/src/lib.rs
@@ -7,6 +7,7 @@ use debug::Debug;
 use download::Download;
 use info::Info;
 use install::Install;
+use install_rockspec::InstallRockspec;
 use list::ListCmd;
 use outdated::Outdated;
 use path::Path;
@@ -30,6 +31,7 @@ pub mod format;
 pub mod info;
 pub mod install;
 pub mod install_lua;
+pub mod install_rockspec;
 pub mod list;
 pub mod outdated;
 pub mod path;
@@ -110,7 +112,7 @@ pub struct Cli {
 pub enum Commands {
     /// [UNIMPLEMENTED] Add a dependency to the current project.
     Add,
-    /// Build/compile a rock.
+    /// Build/compile a project.
     Build(Build),
     /// Runs `luacheck` in the current project.
     Check,
@@ -131,6 +133,9 @@ pub enum Commands {
     /// Install a rock for use on the system.
     #[command(arg_required_else_help = true)]
     Install(Install),
+    /// Install a local RockSpec for use on the system.
+    #[command(arg_required_else_help = true)]
+    InstallRockspec(InstallRockspec),
     /// Manually install and manage Lua headers for various Lua versions.
     InstallLua,
     /// [UNIMPLEMENTED] Check syntax of a rockspec.

--- a/rocks-bin/src/main.rs
+++ b/rocks-bin/src/main.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 use rocks::{
     build, check,
     debug::Debug,
-    download, fetch, format, info, install, install_lua, list, outdated, path, pin, project, purge,
-    remove, run, run_lua, search, test, unpack, update,
+    download, fetch, format, info, install, install_lua, install_rockspec, list, outdated, path,
+    pin, project, purge, remove, run, run_lua, search, test, unpack, update,
     upload::{self},
     Cli, Commands,
 };
@@ -56,6 +56,11 @@ async fn main() {
         Commands::List(list_data) => list::list_installed(list_data, config).unwrap(),
         Commands::Lua(run_lua) => run_lua::run_lua(run_lua, config).await.unwrap(),
         Commands::Install(install_data) => install::install(install_data, config).await.unwrap(),
+        Commands::InstallRockspec(install_data) => {
+            install_rockspec::install_rockspec(install_data, config)
+                .await
+                .unwrap()
+        }
         Commands::Outdated(outdated) => outdated::outdated(outdated, config).await.unwrap(),
         Commands::InstallLua => install_lua::install_lua(config).await.unwrap(),
         Commands::Fmt => format::format().unwrap(),

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/README.md
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/README.md
@@ -1,0 +1,1 @@
+A sample project where the lockfile does not have all test dependencies.

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/lua/foo.lua
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/lua/foo.lua
@@ -1,0 +1,1 @@
+return true

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/project.rockspec
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/project.rockspec
@@ -5,7 +5,7 @@ version = "1.0.0-1"
 dependencies = {
     "lua >= 5.1",
     "pathlib.nvim == 2.2.3",
-    "rtp.nvim == 1.2.0",
+    -- "rtp.nvim == 1.2.0",
 }
 
 source = {

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/project.rockspec
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/project.rockspec
@@ -1,0 +1,13 @@
+rockspec_format = "3.0"
+package = "foo"
+version = "1.0.0-1"
+
+dependencies = {
+    "lua >= 5.1",
+    "pathlib.nvim == 2.2.3",
+    "rtp.nvim == 1.2.0",
+}
+
+source = {
+  url = 'https://github.com/nvim-neorocks/luarocks-stub',
+}

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/rocks.lock
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/rocks.lock
@@ -1,0 +1,34 @@
+{
+  "version": "1.0.0",
+  "rocks": {
+    "5f37e8dc4251f549b25ec62138484f4912ae3d332e57bdb1b30184db3f59d270": {
+      "name": "pathlib.nvim",
+      "version": "2.2.3-1",
+      "pinned": false,
+      "dependencies": [
+        "d7142f441ca59ebde5927d8a3489966828c6b6655125616485632a1b16362f8e"
+      ],
+      "constraint": "=2.2.3",
+      "source": "luarocks_rockspec+https://luarocks.org/",
+      "hashes": {
+        "rockspec": "sha256-kdDMqznWlwP9wIqlzPrZ5qEDp6edhlkaasAcQzWTmmM=",
+        "source": "sha256-arCZdCc4g0VvlQA11V1sHMS7WFSJqfwXC80o0A2igqo="
+      }
+    },
+    "d7142f441ca59ebde5927d8a3489966828c6b6655125616485632a1b16362f8e": {
+      "name": "nvim-nio",
+      "version": "1.10.0-1",
+      "pinned": false,
+      "dependencies": [],
+      "constraint": ">=1.8.0",
+      "source": "luarocks_rockspec+https://luarocks.org/",
+      "hashes": {
+        "rockspec": "sha256-5iL9++6X/JsKKtpIRaRHcnZpn6DrsAQQRWPubZK9erY=",
+        "source": "sha256-WPVTNoj0POenpqKhTWpyPqLe2+fXxpQC2mTU0NvC8Xw="
+      }
+    }
+  },
+  "entrypoints": [
+    "5f37e8dc4251f549b25ec62138484f4912ae3d332e57bdb1b30184db3f59d270"
+  ]
+}

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/rocks.lock
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/rocks.lock
@@ -12,7 +12,7 @@
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-kdDMqznWlwP9wIqlzPrZ5qEDp6edhlkaasAcQzWTmmM=",
-        "source": "sha256-arCZdCc4g0VvlQA11V1sHMS7WFSJqfwXC80o0A2igqo="
+        "source": "sha256-fNO24tL8wApI8j3rk2mdLf5wbbjlUzsvCxki3n0xRw8="
       }
     },
     "d7142f441ca59ebde5927d8a3489966828c6b6655125616485632a1b16362f8e": {
@@ -24,7 +24,7 @@
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-5iL9++6X/JsKKtpIRaRHcnZpn6DrsAQQRWPubZK9erY=",
-        "source": "sha256-WPVTNoj0POenpqKhTWpyPqLe2+fXxpQC2mTU0NvC8Xw="
+        "source": "sha256-wbN0gqfxaFgVcFc8EQl2Y8Cccd7jIPtdTMhHRQe5MSU="
       }
     }
   },

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -242,7 +242,7 @@ async fn do_build(build: Build<'_>) -> Result<LocalPackage, BuildError> {
 
     let temp_dir = tempdir::TempDir::new(&build.rockspec.package.to_string())?;
 
-    operations::FetchSrc::new(
+    let source_hash = operations::FetchSrc::new(
         temp_dir.path(),
         build.rockspec,
         build.config,
@@ -253,7 +253,7 @@ async fn do_build(build: Build<'_>) -> Result<LocalPackage, BuildError> {
 
     let hashes = LocalPackageHashes {
         rockspec: build.rockspec.hash()?,
-        source: temp_dir.hash()?,
+        source: source_hash,
     };
 
     if let Some(expected) = &build.rockspec.source.current_platform().integrity {

--- a/rocks-lib/src/manifest/mod.rs
+++ b/rocks-lib/src/manifest/mod.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use mlua::{Lua, LuaSerdeExt};
 use reqwest::{header::ToStrError, Client};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use std::{cmp::Ordering, collections::HashMap};
 use thiserror::Error;
 use tokio::{fs, io};
@@ -90,7 +90,13 @@ async fn manifest_from_server(
 
     // If our cache file does not exist then pull the whole manifest.
 
-    let new_manifest = client.get(url).send().await?.text().await?;
+    let new_manifest = client
+        .get(url)
+        .timeout(Duration::from_secs(60 * 10))
+        .send()
+        .await?
+        .text()
+        .await?;
 
     fs::write(&cache, &new_manifest).await?;
 

--- a/rocks-lib/src/manifest/mod.rs
+++ b/rocks-lib/src/manifest/mod.rs
@@ -141,14 +141,6 @@ impl ManifestMetadata {
         self.repository.contains_key(rock_name)
     }
 
-    pub fn latest_version(&self, rock_name: &PackageName) -> Option<&PackageVersion> {
-        if !self.has_rock(rock_name) {
-            return None;
-        }
-
-        self.repository[rock_name].keys().sorted().last()
-    }
-
     pub fn latest_match(
         &self,
         lua_package_req: &PackageReq,
@@ -241,7 +233,9 @@ impl Manifest {
     pub fn metadata(&self) -> &ManifestMetadata {
         &self.metadata
     }
-    pub fn search(
+
+    /// Find a package that matches the requirement, returning the latest match
+    pub fn find(
         &self,
         package_req: &PackageReq,
         filter: Option<RemotePackageTypeFilterSpec>,

--- a/rocks-lib/src/operations/download.rs
+++ b/rocks-lib/src/operations/download.rs
@@ -142,6 +142,9 @@ pub(crate) enum RemoteRockDownload {
 
 impl RemoteRockDownload {
     pub fn rockspec(&self) -> &Rockspec {
+        &self.rockspec_download().rockspec
+    }
+    pub fn rockspec_download(&self) -> &DownloadedRockspec {
         match self {
             Self::RockspecOnly { rockspec_download }
             | Self::BinaryRock {
@@ -149,7 +152,7 @@ impl RemoteRockDownload {
             }
             | Self::SrcRock {
                 rockspec_download, ..
-            } => &rockspec_download.rockspec,
+            } => rockspec_download,
         }
     }
 }

--- a/rocks-lib/src/operations/fetch.rs
+++ b/rocks-lib/src/operations/fetch.rs
@@ -112,7 +112,8 @@ pub enum FetchSrcRockError {
 }
 
 async fn do_fetch_src(fetch: &FetchSrc<'_>) -> Result<(), FetchSrcError> {
-    let rock_source = fetch.rockspec.source.current_platform();
+    let rockspec = fetch.rockspec;
+    let rock_source = rockspec.source.current_platform();
     let progress = fetch.progress;
     let dest_dir = fetch.dest_dir;
     match &rock_source.source_spec {

--- a/rocks-lib/src/operations/lockfile_update.rs
+++ b/rocks-lib/src/operations/lockfile_update.rs
@@ -1,0 +1,158 @@
+use bon::Builder;
+use futures::future::join_all;
+use itertools::Itertools;
+use std::{collections::HashMap, io, sync::Arc};
+use thiserror::Error;
+
+use crate::{
+    build::BuildBehaviour,
+    config::Config,
+    hash::HasIntegrity,
+    lockfile::{LocalPackage, LocalPackageHashes, LocalPackageId, Lockfile, PinnedState, ReadOnly},
+    operations::get_all_dependencies,
+    package::{PackageReq, PackageSpec},
+    progress::{MultiProgress, Progress},
+    remote_package_db::{RemotePackageDB, RemotePackageDBError},
+};
+
+use super::{FetchSrc, FetchSrcError, SearchAndDownloadError};
+
+/// A rocks lockfile updater.
+#[derive(Builder)]
+#[builder(start_fn = new, finish_fn(name = _update, vis = ""))]
+pub struct LockfileUpdate<'a> {
+    #[builder(start_fn)]
+    lockfile: &'a mut Lockfile<ReadOnly>,
+
+    #[builder(start_fn)]
+    config: &'a Config,
+
+    #[builder(field)]
+    packages: Vec<PackageReq>,
+
+    package_db: Option<RemotePackageDB>,
+
+    #[builder(default)]
+    pin: PinnedState,
+
+    #[builder(default = MultiProgress::new_arc())]
+    progress: Arc<Progress<MultiProgress>>,
+}
+
+impl<'a, State: lockfile_update_builder::State> LockfileUpdateBuilder<'a, State> {
+    pub fn package(mut self, package: PackageReq) -> Self {
+        self.packages.push(package);
+        self
+    }
+
+    pub fn packages(mut self, packages: impl IntoIterator<Item = PackageReq>) -> Self {
+        self.packages.extend(packages);
+        self
+    }
+
+    /// Add packages that are not already present in the lockfile to the lockfile
+    /// This downloads the RockSpecs and sources to determine their hashes.
+    pub async fn add_missing_packages(self) -> Result<(), LockfileUpdateError> {
+        do_add_missing_packages(self._update()).await
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum LockfileUpdateError {
+    #[error("error initialising remote package DB: {0}")]
+    RemotePackageDB(#[from] RemotePackageDBError),
+    #[error(transparent)]
+    SearchAndDownload(#[from] SearchAndDownloadError),
+    #[error("failed to fetch rock source: {0}")]
+    FetchSrcError(#[from] FetchSrcError),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+async fn do_add_missing_packages(update: LockfileUpdate<'_>) -> Result<(), LockfileUpdateError> {
+    let package_db = match update.package_db {
+        Some(db) => db,
+        None => RemotePackageDB::from_config(update.config).await?,
+    };
+    let lockfile = update.lockfile;
+    let packages_to_add = update
+        .packages
+        .iter()
+        .filter(|pkg| lockfile.has_rock(pkg, None).is_none())
+        .map(|pkg| (BuildBehaviour::NoForce, pkg.clone()))
+        .collect_vec();
+
+    if packages_to_add.is_empty() {
+        return Ok(());
+    }
+
+    let bar = update.progress.map(|p| p.new_bar());
+    bar.map(|b| b.set_message("🔐 Updating lockfile..."));
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    get_all_dependencies(
+        tx,
+        packages_to_add,
+        update.pin,
+        Arc::new(package_db),
+        Arc::new(lockfile.clone()),
+        update.config,
+        update.progress.clone(),
+    )
+    .await?;
+
+    let mut all_packages = HashMap::with_capacity(rx.len());
+    while let Some(dep) = rx.recv().await {
+        all_packages.insert(dep.spec.id(), dep);
+    }
+    let packages_to_add = join_all(all_packages.clone().into_values().map(|install_spec| {
+        let config = update.config.clone();
+        tokio::spawn(async move {
+            let downloaded_rock = install_spec.downloaded_rock;
+            let rockspec = downloaded_rock.rockspec();
+            let temp_dir =
+                tempdir::TempDir::new(&format!("lockfile_update-{}", &rockspec.package))?;
+            FetchSrc::new(temp_dir.path(), rockspec, &config, &Progress::NoProgress)
+                .fetch()
+                .await?;
+            let hashes = LocalPackageHashes {
+                rockspec: rockspec.hash()?,
+                source: temp_dir.hash()?,
+            };
+            let pkg = LocalPackage::from(
+                &PackageSpec::new(rockspec.package.clone(), rockspec.version.clone()),
+                install_spec.spec.constraint(),
+                downloaded_rock.rockspec_download().source.clone(),
+                hashes,
+            );
+            Ok::<_, LockfileUpdateError>((pkg.id(), pkg))
+        })
+    }))
+    .await
+    .into_iter()
+    .flatten()
+    .try_collect::<_, HashMap<LocalPackageId, LocalPackage>, _>()?;
+
+    lockfile.map_then_flush(|lockfile| {
+        packages_to_add.iter().for_each(|(id, pkg)| {
+            lockfile.add(pkg);
+
+            all_packages
+                .get(id)
+                .map(|pkg| pkg.spec.dependencies())
+                .unwrap_or_default()
+                .into_iter()
+                .for_each(|dependency_id| {
+                    if let Some(dependency) = packages_to_add.get(dependency_id) {
+                        lockfile.add_dependency(pkg, dependency)
+                    }
+                });
+        });
+
+        Ok::<_, io::Error>(())
+    })?;
+
+    bar.map(|b| b.finish_and_clear());
+
+    Ok(())
+}

--- a/rocks-lib/src/operations/lockfile_update.rs
+++ b/rocks-lib/src/operations/lockfile_update.rs
@@ -112,12 +112,13 @@ async fn do_add_missing_packages(update: LockfileUpdate<'_>) -> Result<(), Lockf
             let rockspec = downloaded_rock.rockspec();
             let temp_dir =
                 tempdir::TempDir::new(&format!("lockfile_update-{}", &rockspec.package))?;
-            FetchSrc::new(temp_dir.path(), rockspec, &config, &Progress::NoProgress)
-                .fetch()
-                .await?;
+            let source_hash =
+                FetchSrc::new(temp_dir.path(), rockspec, &config, &Progress::NoProgress)
+                    .fetch()
+                    .await?;
             let hashes = LocalPackageHashes {
                 rockspec: rockspec.hash()?,
-                source: temp_dir.hash()?,
+                source: source_hash,
             };
             let pkg = LocalPackage::from(
                 &PackageSpec::new(rockspec.package.clone(), rockspec.version.clone()),

--- a/rocks-lib/src/operations/mod.rs
+++ b/rocks-lib/src/operations/mod.rs
@@ -3,6 +3,7 @@
 mod download;
 mod fetch;
 mod install;
+mod lockfile_update;
 mod pin;
 mod remove;
 mod resolve;
@@ -14,6 +15,7 @@ mod update;
 pub use download::*;
 pub use fetch::*;
 pub use install::*;
+pub use lockfile_update::*;
 pub use pin::*;
 pub use remove::*;
 pub use run::*;

--- a/rocks-lib/src/operations/pin.rs
+++ b/rocks-lib/src/operations/pin.rs
@@ -37,7 +37,7 @@ pub fn set_pinned_state(
     tree: &Tree,
     pin: PinnedState,
 ) -> Result<(), PinError> {
-    let lockfile = tree.lockfile()?;
+    let mut lockfile = tree.lockfile()?;
     let mut package = lockfile
         .get(package_id)
         .ok_or_else(|| PinError::PackageNotFound(package_id.clone()))?

--- a/rocks-lib/src/operations/remove.rs
+++ b/rocks-lib/src/operations/remove.rs
@@ -76,7 +76,7 @@ async fn remove(
     tree: Tree,
     progress: &Progress<MultiProgress>,
 ) -> Result<(), RemoveError> {
-    let lockfile = tree.lockfile()?;
+    let mut lockfile = tree.lockfile()?;
 
     let packages = package_ids
         .iter()

--- a/rocks-lib/src/operations/resolve.rs
+++ b/rocks-lib/src/operations/resolve.rs
@@ -45,7 +45,8 @@ where
             .into_iter()
             // Exclude packages that are already installed
             .filter(|(build_behaviour, package)| {
-                build_behaviour == &BuildBehaviour::Force || lockfile.has_rock(package).is_none()
+                build_behaviour == &BuildBehaviour::Force
+                    || lockfile.has_rock(package, None).is_none()
             })
             .map(|(build_behaviour, package)| {
                 let config = config.clone();

--- a/rocks-lib/src/package/mod.rs
+++ b/rocks-lib/src/package/mod.rs
@@ -204,6 +204,14 @@ impl From<PackageSpec> for PackageReq {
     }
 }
 
+impl From<PackageName> for PackageReq {
+    fn from(name: PackageName) -> Self {
+        Self {
+            name,
+            version_req: PackageVersionReq::default(),
+        }
+    }
+}
 #[cfg(feature = "lua")]
 impl mlua::UserData for PackageReq {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {

--- a/rocks-lib/src/package/outdated.rs
+++ b/rocks-lib/src/package/outdated.rs
@@ -28,8 +28,8 @@ impl PackageSpec {
             .latest_version(&self.name)
             .ok_or_else(|| RockNotFound(self.name.clone()))?;
 
-        if self.version < *latest_version {
-            Ok(Some(latest_version.to_owned()))
+        if self.version < latest_version {
+            Ok(Some(latest_version))
         } else {
             Ok(None)
         }

--- a/rocks-lib/src/project/mod.rs
+++ b/rocks-lib/src/project/mod.rs
@@ -7,7 +7,8 @@ use thiserror::Error;
 
 use crate::{
     config::LuaVersion,
-    rockspec::{Rockspec, RockspecError},
+    lockfile::{Lockfile, ReadOnly},
+    rockspec::{RockSourceSpec, Rockspec, RockspecError},
     tree::Tree,
 };
 
@@ -59,15 +60,39 @@ impl Project {
             None => Ok(None),
         }
     }
-}
 
-impl Project {
+    /// Get the `rocks.lock` lockfile path.
+    pub fn lockfile_path(&self) -> PathBuf {
+        self.root.join("rocks.lock")
+    }
+
+    /// Get the `rocks.lock` lockfile in the project root, if present.
+    pub fn lockfile(&self) -> Result<Option<Lockfile<ReadOnly>>, ProjectError> {
+        let path = self.lockfile_path();
+        if path.is_file() {
+            Ok(Some(Lockfile::new(path)?))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn root(&self) -> &Path {
         &self.root
     }
 
     pub fn rockspec(&self) -> &Rockspec {
         &self.rockspec
+    }
+
+    /// Create a RockSpec with the source set to the project root.
+    pub fn new_local_rockspec(&self) -> Rockspec {
+        let mut rockspec = self.rockspec().clone();
+        let mut source = rockspec.source.current_platform().clone();
+        source.source_spec = RockSourceSpec::File(self.root().to_path_buf());
+        source.archive_name = None;
+        source.integrity = None;
+        rockspec.source.current_platform_set(source);
+        rockspec
     }
 
     pub fn tree(&self, lua_version: LuaVersion) -> io::Result<Tree> {

--- a/rocks-lib/src/remote_package_db/mod.rs
+++ b/rocks-lib/src/remote_package_db/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::Config,
+    lockfile::{LocalPackage, Lockfile, LockfileIntegrityError, ReadOnly},
     manifest::{Manifest, ManifestError},
     package::{
         PackageName, PackageReq, PackageSpec, PackageVersion, RemotePackage,
@@ -7,11 +8,17 @@ use crate::{
     },
     progress::{Progress, ProgressBar},
 };
-use itertools::Itertools as _;
+use itertools::Itertools;
 use thiserror::Error;
 
 #[derive(Clone)]
-pub struct RemotePackageDB(Vec<Manifest>);
+pub struct RemotePackageDB(Impl);
+
+#[derive(Clone)]
+enum Impl {
+    LuarocksManifests(Vec<Manifest>),
+    Lockfile(Lockfile<ReadOnly>),
+}
 
 #[derive(Error, Debug)]
 pub enum RemotePackageDBError {
@@ -25,8 +32,16 @@ pub enum SearchError {
     Mlua(#[from] mlua::Error),
     #[error("no rock that matches '{0}' found")]
     RockNotFound(PackageReq),
+    #[error("no rock that matches '{0}' found in the lockfile.")]
+    RockNotFoundInLockfile(PackageReq),
     #[error("error when pulling manifest: {0}")]
     Manifest(#[from] ManifestError),
+}
+
+#[derive(Error, Debug)]
+pub enum RemotePackageDbIntegrityError {
+    #[error(transparent)]
+    Lockfile(#[from] LockfileIntegrityError),
 }
 
 impl RemotePackageDB {
@@ -37,80 +52,121 @@ impl RemotePackageDB {
             manifests.push(manifest);
         }
         manifests.push(Manifest::from_config(config.server().clone(), config).await?);
-        Ok(Self(manifests))
+        Ok(Self(Impl::LuarocksManifests(manifests)))
     }
 
-    /// Find a package that matches the requirement
+    /// Find a remote package that matches the requirement, returning the latest match.
     pub(crate) fn find(
         &self,
         package_req: &PackageReq,
         filter: Option<RemotePackageTypeFilterSpec>,
         progress: &Progress<ProgressBar>,
     ) -> Result<RemotePackage, SearchError> {
-        let result = self.0.iter().find_map(|manifest| {
-            progress.map(|p| p.set_message(format!("🔎 Searching {}", &manifest.server_url())));
-            manifest.search(package_req, filter.clone())
-        });
-        match result {
-            Some(package) => Ok(package),
-            None => Err(SearchError::RockNotFound(package_req.clone())),
+        match &self.0 {
+            Impl::LuarocksManifests(manifests) => match manifests.iter().find_map(|manifest| {
+                progress.map(|p| p.set_message(format!("🔎 Searching {}", &manifest.server_url())));
+                manifest.find(package_req, filter.clone())
+            }) {
+                Some(package) => Ok(package),
+                None => Err(SearchError::RockNotFound(package_req.clone())),
+            },
+            Impl::Lockfile(lockfile) => {
+                match lockfile.has_rock(package_req, filter).map(|local_package| {
+                    RemotePackage::new(
+                        PackageSpec::new(local_package.spec.name, local_package.spec.version),
+                        local_package.source,
+                    )
+                }) {
+                    Some(package) => Ok(package),
+                    None => Err(SearchError::RockNotFoundInLockfile(package_req.clone())),
+                }
+            }
         }
     }
 
-    /// Search for all packages that match the requirement
+    /// Search for all packages that match the requirement.
     pub fn search(&self, package_req: &PackageReq) -> Vec<(&PackageName, Vec<&PackageVersion>)> {
-        self.0
-            .iter()
-            .flat_map(|manifest| {
-                manifest
-                    .metadata()
-                    .repository
-                    .iter()
-                    .filter_map(|(name, elements)| {
-                        if name.to_string().contains(&package_req.name().to_string()) {
-                            Some((
-                                name,
-                                elements
-                                    .keys()
-                                    .filter(|version| package_req.version_req().matches(version))
-                                    .sorted_by(|a, b| Ord::cmp(b, a))
-                                    .collect_vec(),
-                            ))
-                        } else {
-                            None
-                        }
-                    })
-            })
-            .collect()
+        match &self.0 {
+            Impl::LuarocksManifests(manifests) => manifests
+                .iter()
+                .flat_map(|manifest| {
+                    manifest
+                        .metadata()
+                        .repository
+                        .iter()
+                        .filter_map(|(name, elements)| {
+                            if name.to_string().contains(&package_req.name().to_string()) {
+                                Some((
+                                    name,
+                                    elements
+                                        .keys()
+                                        .filter(|version| {
+                                            package_req.version_req().matches(version)
+                                        })
+                                        .sorted_by(|a, b| Ord::cmp(b, a))
+                                        .collect_vec(),
+                                ))
+                            } else {
+                                None
+                            }
+                        })
+                })
+                .collect(),
+            Impl::Lockfile(lockfile) => lockfile
+                .rocks()
+                .iter()
+                .filter_map(|(_, package)| {
+                    // NOTE: This doesn't group packages by name, but we don't care for now,
+                    // as we shouldn't need to use this function with a lockfile.
+                    let name = package.name();
+                    if name.to_string().contains(&package_req.name().to_string()) {
+                        Some((name, vec![package.version()]))
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec(),
+        }
     }
 
-    pub fn latest_version(&self, rock_name: &PackageName) -> Option<&PackageVersion> {
-        self.0
-            .iter()
-            .filter_map(|manifest| manifest.metadata().latest_version(rock_name))
-            .sorted()
-            .last()
+    /// Find the latest version for a package by name.
+    pub(crate) fn latest_version(&self, rock_name: &PackageName) -> Option<PackageVersion> {
+        self.latest_match(&rock_name.clone().into(), None)
+            .map(|result| result.version().clone())
     }
 
+    /// Find the latest package that matches the requirement.
     pub fn latest_match(
         &self,
         package_req: &PackageReq,
         filter: Option<RemotePackageTypeFilterSpec>,
     ) -> Option<PackageSpec> {
-        self.0
-            .iter()
-            .filter_map(|manifest| {
-                manifest
-                    .metadata()
-                    .latest_match(package_req, filter.clone())
-                    .map(|x| x.0)
-            })
-            .last()
+        match self.find(package_req, filter, &Progress::NoProgress) {
+            Ok(result) => Some(result.package),
+            Err(_) => None,
+        }
+    }
+
+    /// Validate the integrity of an installed package.
+    pub(crate) fn validate_integrity(
+        &self,
+        package: &LocalPackage,
+    ) -> Result<(), RemotePackageDbIntegrityError> {
+        match &self.0 {
+            Impl::LuarocksManifests(_) => Ok(()),
+            Impl::Lockfile(lockfile) => Ok(lockfile.validate_integrity(package)?),
+        }
     }
 }
 
 impl From<Manifest> for RemotePackageDB {
     fn from(manifest: Manifest) -> Self {
-        RemotePackageDB(vec![manifest])
+        Self(Impl::LuarocksManifests(vec![manifest]))
+    }
+}
+
+impl From<Lockfile<ReadOnly>> for RemotePackageDB {
+    fn from(lockfile: Lockfile<ReadOnly>) -> Self {
+        Self(Impl::Lockfile(lockfile))
     }
 }

--- a/rocks-lib/src/rockspec/platform.rs
+++ b/rocks-lib/src/rockspec/platform.rs
@@ -296,8 +296,16 @@ impl<T> PerPlatform<T> {
         )
     }
 
+    fn set(&mut self, platform: PlatformIdentifier, value: T) {
+        self.per_platform.insert(platform, value);
+    }
+
     pub fn current_platform(&self) -> &T {
         self.get(&get_platform())
+    }
+
+    pub(crate) fn current_platform_set(&mut self, value: T) {
+        self.set(get_platform(), value)
     }
 }
 

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -209,7 +209,12 @@ impl Tree {
     }
 
     pub fn lockfile(&self) -> io::Result<Lockfile<ReadOnly>> {
-        Lockfile::new(self.root().join("lock.json"))
+        Lockfile::new(self.lockfile_path())
+    }
+
+    /// Get this tree's lockfile path.
+    pub fn lockfile_path(&self) -> PathBuf {
+        self.root().join("lock.json")
     }
 }
 


### PR DESCRIPTION
This PR:

- Introduces a `RocksPackageDB` implementation using a lockfile.
- Uses that implementation to provide reproducible project builds, with rockspec/source integrity checks.

Breaking:

- `rocks build` it now builds the current project,
  using a clone of the rockspec with the project root as the source.
  This is now equivalent to `luarocks make` or `cargo build`.
- Introduced a separate `install-rockspec` command for installing local rockspecs.
  - Removed the `--force` flag, because if we're building from a project or local rockspec, we probably always want to force.