### PR TITLE
refactor(build): move builder to `derive-builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,8 +684,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -702,14 +712,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -735,6 +770,37 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.87",
 ]
 
@@ -2928,6 +2994,7 @@ dependencies = [
  "bytes",
  "cc",
  "clap 4.5.23",
+ "derive_builder",
  "dir-diff",
  "directories",
  "flate2",
@@ -3179,7 +3246,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb8ec7724e4e524b2492b510e66957fe1a2c76c26a6975ec80823f2439da685"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "serde-rename-rule",
  "syn 1.0.109",
 ]
@@ -3190,7 +3257,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26416dc95fcd46b0e4b12a3758043a229a6914050aaec2e8191949753ed4e9aa"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "serde-attributes",

--- a/rocks-bin/src/build.rs
+++ b/rocks-bin/src/build.rs
@@ -119,7 +119,10 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
         .install()
         .await?;
 
-    build::Build::new(&rockspec, &config, &progress.map(|p| p.new_bar()))
+    build::Build::default()
+        .rockspec(&rockspec)
+        .config(&config)
+        .progress(&progress.map(|p| p.new_bar()))
         .pin(pin)
         .behaviour(build_behaviour)
         .build()

--- a/rocks-lib/Cargo.toml
+++ b/rocks-lib/Cargo.toml
@@ -53,6 +53,7 @@ shell-words = "1.1.0"
 shlex = "1.3.0"
 pkg-config = "0.3.31"
 url = "2.5.4"
+derive_builder = "0.20.2"
 
 [dev-dependencies]
 httptest = { version = "0.16.1" }

--- a/rocks-lib/src/luarocks/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks/luarocks_installation.rs
@@ -104,12 +104,16 @@ impl LuaRocksInstallation {
             PackageReq::new("luarocks".into(), Some(LUAROCKS_VERSION.into())).unwrap();
         if !self.tree.match_rocks(&luarocks_req)?.is_found() {
             let rockspec = Rockspec::new(LUAROCKS_ROCKSPEC).unwrap();
-            let pkg = Build::new(&rockspec, &self.config, progress)
+            let pkg = Build::default()
+                .rockspec(&rockspec)
+                .config(&self.config)
+                .progress(progress)
                 .constraint(LockConstraint::Constrained(
                     luarocks_req.version_req().clone(),
                 ))
                 .build()
                 .await?;
+
             lockfile.add(&pkg);
         }
         lockfile.flush()?;
@@ -171,7 +175,10 @@ impl LuaRocksInstallation {
             let config = self.config.clone();
             tokio::spawn(async move {
                 let rockspec = install_spec.downloaded_rock.rockspec();
-                let pkg = Build::new(rockspec, &config, &bar)
+                let pkg = Build::default()
+                    .rockspec(rockspec)
+                    .config(&config)
+                    .progress(&bar)
                     .constraint(install_spec.spec.constraint())
                     .behaviour(install_spec.build_behaviour)
                     .build()

--- a/rocks-lib/src/operations/install.rs
+++ b/rocks-lib/src/operations/install.rs
@@ -271,7 +271,10 @@ async fn install_rockspec(
             .await?;
     }
 
-    let pkg = Build::new(&rockspec, config, &bar)
+    let pkg = Build::default()
+        .rockspec(&rockspec)
+        .config(config)
+        .progress(&bar)
         .pin(pin)
         .constraint(constraint)
         .behaviour(behaviour)

--- a/rocks-lib/src/remote_package_source/mod.rs
+++ b/rocks-lib/src/remote_package_source/mod.rs
@@ -11,7 +11,7 @@ const PLUS: &str = "+";
 
 /// The source of a remote package.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub(crate) enum RemotePackageSource {
+pub enum RemotePackageSource {
     LuarocksRockspec(Url),
     LuarocksSrcRock(Url),
     LuarocksBinaryRock(Url),

--- a/rocks-lib/tests/build.rs
+++ b/rocks-lib/tests/build.rs
@@ -25,7 +25,10 @@ async fn builtin_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(&rockspec, &config, &Progress::Progress(bar))
+    Build::default()
+        .rockspec(&rockspec)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -50,7 +53,10 @@ async fn make_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(&rockspec, &config, &Progress::Progress(bar))
+    Build::default()
+        .rockspec(&rockspec)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -87,7 +93,10 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(&rockspec, &config, &Progress::Progress(bar))
+    Build::default()
+        .rockspec(&rockspec)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await


### PR DESCRIPTION
This moves the `build` builder to derive-builder instead, giving us full runtime checks.

Feel free to neglect or nitpick these changes, I'm not sure if this is something we want in our codebase. It seems to work very well though and integrates with our own errors fairly well.