### PR TITLE
fix!: remove associated binaries when deleting a rock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 /*.rockspec
 *.snap.new
 /.rocks
+rocks.lock
 
 .pre-commit-config.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clean-path"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa6b4b263a5d737e9bf6b7c09b72c41a5480aec4d7219af827f6564e950b6a5"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,6 +3005,7 @@ dependencies = [
  "bytes",
  "cc",
  "clap 4.5.23",
+ "clean-path",
  "dir-diff",
  "directories",
  "flate2",

--- a/rocks-lib/Cargo.toml
+++ b/rocks-lib/Cargo.toml
@@ -54,6 +54,7 @@ shlex = "1.3.0"
 pkg-config = "0.3.31"
 url = "2.5.4"
 bon = { version = "3.3.2", features = ["implied-bounds"] }
+clean-path = "0.2.1"
 
 [dev-dependencies]
 httptest = { version = "0.16.1" }

--- a/rocks-lib/resources/test/sample-project-lockfile-missing-deps/rocks.lock
+++ b/rocks-lib/resources/test/sample-project-lockfile-missing-deps/rocks.lock
@@ -10,6 +10,7 @@
       ],
       "constraint": "=2.2.3",
       "source": "luarocks_rockspec+https://luarocks.org/",
+      "binaries": [],
       "hashes": {
         "rockspec": "sha256-kdDMqznWlwP9wIqlzPrZ5qEDp6edhlkaasAcQzWTmmM=",
         "source": "sha256-fNO24tL8wApI8j3rk2mdLf5wbbjlUzsvCxki3n0xRw8="
@@ -21,6 +22,7 @@
       "pinned": false,
       "dependencies": [],
       "constraint": ">=1.8.0",
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-5iL9++6X/JsKKtpIRaRHcnZpn6DrsAQQRWPubZK9erY=",

--- a/rocks-lib/resources/test/sample-tree/5.1/lock.json
+++ b/rocks-lib/resources/test/sample-tree/5.1/lock.json
@@ -9,6 +9,7 @@
         "48ec344951668eca0e0a4ff284d804a11e4e709194df3191a72ed8fac89cf2e0"
       ],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -21,6 +22,7 @@
       "pinned": false,
       "dependencies": [],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -34,6 +36,7 @@
       "dependencies": [
         "48ec344951668eca0e0a4ff284d804a11e4e709194df3191a72ed8fac89cf2e0"
       ],
+      "binaries": [],
       "constraint": null,
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {

--- a/rocks-lib/src/build/cmake.rs
+++ b/rocks-lib/src/build/cmake.rs
@@ -10,7 +10,7 @@ use crate::{
     config::Config,
     lua_installation::LuaInstallation,
     progress::{Progress, ProgressBar},
-    rockspec::{Build, CMakeBuildSpec},
+    rockspec::{Build, BuildInfo, CMakeBuildSpec},
     tree::RockLayout,
 };
 
@@ -46,7 +46,7 @@ impl Build for CMakeBuildSpec {
         config: &Config,
         build_dir: &Path,
         _progress: &Progress<ProgressBar>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<BuildInfo, Self::Err> {
         let mut args = Vec::new();
         if let Some(content) = self.cmake_lists_content {
             let cmakelists = build_dir.join("CMakeLists.txt");
@@ -101,7 +101,7 @@ impl Build for CMakeBuildSpec {
             )?;
         }
 
-        Ok(())
+        Ok(BuildInfo::default())
     }
 }
 

--- a/rocks-lib/src/build/command.rs
+++ b/rocks-lib/src/build/command.rs
@@ -10,7 +10,7 @@ use crate::{
     config::Config,
     lua_installation::LuaInstallation,
     progress::{Progress, ProgressBar},
-    rockspec::{Build, CommandBuildSpec},
+    rockspec::{Build, BuildInfo, CommandBuildSpec},
     tree::RockLayout,
 };
 
@@ -44,14 +44,14 @@ impl Build for CommandBuildSpec {
         config: &Config,
         build_dir: &Path,
         progress: &Progress<ProgressBar>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<BuildInfo, Self::Err> {
         progress.map(|bar| bar.set_message("Running build_command..."));
         run_command(&self.build_command, output_paths, lua, config, build_dir)?;
         if !no_install {
             progress.map(|bar| bar.set_message("Running install_command..."));
             run_command(&self.install_command, output_paths, lua, config, build_dir)?;
         }
-        Ok(())
+        Ok(BuildInfo::default())
     }
 }
 

--- a/rocks-lib/src/build/luarocks.rs
+++ b/rocks-lib/src/build/luarocks.rs
@@ -5,7 +5,7 @@ use crate::{
     lua_installation::LuaInstallation,
     luarocks::luarocks_installation::{ExecLuaRocksError, LuaRocksError, LuaRocksInstallation},
     progress::{Progress, ProgressBar},
-    rockspec::Rockspec,
+    rockspec::{BuildInfo, Rockspec},
     tree::RockLayout,
 };
 
@@ -31,7 +31,7 @@ pub(crate) async fn build(
     config: &Config,
     build_dir: &Path,
     progress: &Progress<ProgressBar>,
-) -> Result<(), LuarocksBuildError> {
+) -> Result<BuildInfo, LuarocksBuildError> {
     progress.map(|p| {
         p.set_message(format!(
             "Building {} {} with luarocks...",
@@ -55,7 +55,7 @@ fn install(
     luarocks_tree: &Path,
     output_paths: &RockLayout,
     config: &Config,
-) -> Result<(), LuarocksBuildError> {
+) -> Result<BuildInfo, LuarocksBuildError> {
     let lua_version = rockspec
         .lua_version_from_config(config)
         .expect("could not get lua version!");
@@ -82,5 +82,5 @@ fn install(
         .join("lua")
         .join(lua_version.version_compatibility_str());
     recursive_copy_dir(&lib_dir, &output_paths.lib)?;
-    Ok(())
+    Ok(BuildInfo::default())
 }

--- a/rocks-lib/src/build/make.rs
+++ b/rocks-lib/src/build/make.rs
@@ -11,7 +11,7 @@ use crate::{
     config::Config,
     lua_installation::LuaInstallation,
     progress::{Progress, ProgressBar},
-    rockspec::{Build, MakeBuildSpec},
+    rockspec::{Build, BuildInfo, MakeBuildSpec},
     tree::RockLayout,
 };
 
@@ -41,7 +41,7 @@ impl Build for MakeBuildSpec {
         config: &Config,
         build_dir: &Path,
         _progress: &Progress<ProgressBar>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<BuildInfo, Self::Err> {
         // Build step
         if self.build_pass {
             let build_args = self
@@ -109,6 +109,6 @@ impl Build for MakeBuildSpec {
             }
         };
 
-        Ok(())
+        Ok(BuildInfo::default())
     }
 }

--- a/rocks-lib/src/build/rust_mlua.rs
+++ b/rocks-lib/src/build/rust_mlua.rs
@@ -1,6 +1,7 @@
 use super::utils::lua_lib_extension;
 use crate::config::LuaVersionUnset;
 use crate::progress::{Progress, ProgressBar};
+use crate::rockspec::BuildInfo;
 use crate::{
     config::{Config, LuaVersion},
     lua_installation::LuaInstallation,
@@ -39,7 +40,7 @@ impl Build for RustMluaBuildSpec {
         config: &Config,
         build_dir: &Path,
         progress: &Progress<ProgressBar>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<BuildInfo, Self::Err> {
         let lua_version = LuaVersion::from(config)?;
         let lua_feature = match lua_version {
             LuaVersion::Lua51 => "lua51",
@@ -88,7 +89,7 @@ impl Build for RustMluaBuildSpec {
             cleanup(output_paths, progress).await?;
             return Err(err.into());
         }
-        Ok(())
+        Ok(BuildInfo::default())
     }
 }
 

--- a/rocks-lib/src/lockfile/snapshots/rocks_lib__lockfile__tests__add_rocks.snap
+++ b/rocks-lib/src/lockfile/snapshots/rocks_lib__lockfile__tests__add_rocks.snap
@@ -1,6 +1,5 @@
 ---
 source: rocks-lib/src/lockfile/mod.rs
-assertion_line: 649
 expression: lockfile
 ---
 {
@@ -12,6 +11,7 @@ expression: lockfile
       "pinned": false,
       "dependencies": [],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -26,6 +26,7 @@ expression: lockfile
         "a9f137d1dad1af603e33935a3f8722dfbb2aebeac03bec5ed0b6e9cc5828c7f3"
       ],
       "constraint": null,
+      "binaries": [],
       "source": "test+foo_bar",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -38,6 +39,7 @@ expression: lockfile
       "pinned": true,
       "dependencies": [],
       "constraint": ">=1.0.0",
+      "binaries": [],
       "source": "test+foo_bar",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -52,6 +54,7 @@ expression: lockfile
         "48ec344951668eca0e0a4ff284d804a11e4e709194df3191a72ed8fac89cf2e0"
       ],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -66,6 +69,7 @@ expression: lockfile
         "48ec344951668eca0e0a4ff284d804a11e4e709194df3191a72ed8fac89cf2e0"
       ],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",

--- a/rocks-lib/src/lockfile/snapshots/rocks_lib__lockfile__tests__parse_lockfile.snap
+++ b/rocks-lib/src/lockfile/snapshots/rocks_lib__lockfile__tests__parse_lockfile.snap
@@ -1,8 +1,6 @@
 ---
 source: rocks-lib/src/lockfile/mod.rs
-assertion_line: 603
 expression: lockfile
-snapshot_kind: text
 ---
 {
   "version": "1.0.0",
@@ -13,6 +11,7 @@ snapshot_kind: text
       "pinned": false,
       "dependencies": [],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -27,6 +26,7 @@ snapshot_kind: text
         "48ec344951668eca0e0a4ff284d804a11e4e709194df3191a72ed8fac89cf2e0"
       ],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
@@ -41,6 +41,7 @@ snapshot_kind: text
         "48ec344951668eca0e0a4ff284d804a11e4e709194df3191a72ed8fac89cf2e0"
       ],
       "constraint": null,
+      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",

--- a/rocks-lib/src/luarocks/install_binary_rock.rs
+++ b/rocks-lib/src/luarocks/install_binary_rock.rs
@@ -108,6 +108,7 @@ impl<'a> BinaryRockInstall<'a> {
         let mut package = LocalPackage::from(
             &PackageSpec::new(rockspec.package.clone(), rockspec.version.clone()),
             self.constraint,
+            rockspec.binaries(),
             self.source,
             hashes,
         );

--- a/rocks-lib/src/operations/lockfile_update.rs
+++ b/rocks-lib/src/operations/lockfile_update.rs
@@ -123,6 +123,7 @@ async fn do_add_missing_packages(update: LockfileUpdate<'_>) -> Result<(), Lockf
             let pkg = LocalPackage::from(
                 &PackageSpec::new(rockspec.package.clone(), rockspec.version.clone()),
                 install_spec.spec.constraint(),
+                rockspec.binaries(),
                 downloaded_rock.rockspec_download().source.clone(),
                 hashes,
             );

--- a/rocks-lib/src/operations/resolve.rs
+++ b/rocks-lib/src/operations/resolve.rs
@@ -97,6 +97,7 @@ where
                         constraint,
                         dependencies,
                         &pin,
+                        rockspec.binaries(),
                     );
 
                     let install_spec = PackageInstallSpec {

--- a/rocks-lib/src/rockspec/build/mod.rs
+++ b/rocks-lib/src/rockspec/build/mod.rs
@@ -528,6 +528,11 @@ impl Default for BuildType {
     }
 }
 
+#[derive(Default)]
+pub struct BuildInfo {
+    pub binaries: Vec<PathBuf>,
+}
+
 // TODO(vhyrro): Move this to the dedicated build.rs module
 pub trait Build {
     type Err: std::error::Error;
@@ -540,7 +545,7 @@ pub trait Build {
         config: &Config,
         build_dir: &Path,
         progress: &Progress<ProgressBar>,
-    ) -> impl Future<Output = Result<(), Self::Err>> + Send;
+    ) -> impl Future<Output = Result<BuildInfo, Self::Err>> + Send;
 }
 
 #[cfg(test)]

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -5,7 +5,13 @@ mod rock_source;
 mod serde_util;
 mod test_spec;
 
-use std::{collections::HashMap, io, path::PathBuf, str::FromStr};
+use std::{
+    collections::HashMap,
+    io,
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+    str::FromStr,
+};
 
 use itertools::Itertools;
 use mlua::{FromLua, Lua, LuaSerdeExt, Value};
@@ -105,6 +111,20 @@ impl Rockspec {
         Ok(rockspec)
     }
 
+    /// Shorthand to extract the binaries that are part of the rockspec.
+    // TODO(vhyrro): Move this to the `Rocks` trait during the `rocks.toml` rewrite.
+    pub(crate) fn binaries(&self) -> RockBinaries {
+        RockBinaries(
+            self.build
+                .current_platform()
+                .install
+                .bin
+                .keys()
+                .map_into()
+                .collect(),
+        )
+    }
+
     pub fn validate_lua_version(&self, config: &Config) -> Result<(), LuaVersionError> {
         let _ = self.lua_version_from_config(config)?;
         Ok(())
@@ -165,6 +185,23 @@ fn latest_lua_version(dependencies: &PerPlatform<Vec<PackageReq>>) -> Option<Lua
 
             None
         })
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialOrd, Ord, Hash, PartialEq, Eq)]
+pub struct RockBinaries(Vec<PathBuf>);
+
+impl Deref for RockBinaries {
+    type Target = Vec<PathBuf>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for RockBinaries {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 #[derive(Error, Debug)]

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -334,6 +334,7 @@ mod tests {
         lockfile::{LocalPackage, LocalPackageHashes, LockConstraint},
         package::{PackageName, PackageSpec, PackageVersion},
         remote_package_source::RemotePackageSource,
+        rockspec::RockBinaries,
         tree::RockLayout,
     };
 
@@ -362,6 +363,7 @@ mod tests {
         let package = LocalPackage::from(
             &PackageSpec::parse("neorg".into(), "8.0.0-1".into()).unwrap(),
             LockConstraint::Unconstrained,
+            RockBinaries::default(),
             RemotePackageSource::Test,
             mock_hashes.clone(),
         );
@@ -386,6 +388,7 @@ mod tests {
         let package = LocalPackage::from(
             &PackageSpec::parse("lua-cjson".into(), "2.1.0-1".into()).unwrap(),
             LockConstraint::Unconstrained,
+            RockBinaries::default(),
             RemotePackageSource::Test,
             mock_hashes.clone(),
         );
@@ -462,6 +465,7 @@ mod tests {
             .rock(&LocalPackage::from(
                 &PackageSpec::parse("neorg".into(), "8.0.0-1-1".into()).unwrap(),
                 LockConstraint::Unconstrained,
+                RockBinaries::default(),
                 RemotePackageSource::Test,
                 mock_hashes.clone(),
             ))


### PR DESCRIPTION
This PR keeps track of all binaries installed by a given rock and properly cleans up the binaries when running `rocks remove`.

I also made sure to sanitize the path input before reading its filename just in case to prevent any sort of DOS. Whether it's as effective as I hope should be looked into as part of a security check.
