### PR TITLE
chore: Add `PackageVersionReq::Any` variant

### DIFF
--- a/rocks-bin/src/project/new.rs
+++ b/rocks-bin/src/project/new.rs
@@ -296,7 +296,7 @@ type = "builtin"
                 .into_iter()
                 .map(|label| "\"".to_string() + &label + "\"")
                 .join(", "),
-            lua_version_req = lua_versions.version_req().unwrap(),
+            lua_version_req = lua_versions.version_req(),
         )
         .trim(),
     )?;

--- a/rocks-lib/src/luarocks/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks/luarocks_installation.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use crate::{
     build::{Build, BuildBehaviour, BuildError},
     config::{Config, LuaVersion, LuaVersionUnset},
-    lockfile::{LocalPackage, LocalPackageId, LockConstraint, PinnedState},
+    lockfile::{LocalPackage, LocalPackageId, PinnedState},
     lua_installation::LuaInstallation,
     lua_rockspec::{LuaRockspec, RockspecFormat},
     operations::{get_all_dependencies, SearchAndDownloadError},
@@ -108,13 +108,7 @@ impl LuaRocksInstallation {
         if !self.tree.match_rocks(&luarocks_req)?.is_found() {
             let rockspec = LuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap();
             let pkg = Build::new(&rockspec, &self.config, progress)
-                .constraint(
-                    luarocks_req
-                        .version_req()
-                        .cloned()
-                        .map(LockConstraint::Constrained)
-                        .unwrap_or(LockConstraint::Unconstrained),
-                )
+                .constraint(luarocks_req.version_req().clone().into())
                 .build()
                 .await?;
             lockfile.add(&pkg);

--- a/rocks-lib/src/manifest/mod.rs
+++ b/rocks-lib/src/manifest/mod.rs
@@ -163,12 +163,7 @@ impl ManifestMetadata {
 
         let (version, rock_type) = self.repository[lua_package_req.name()]
             .iter()
-            .filter(|(version, _)| {
-                lua_package_req
-                    .version_req()
-                    .map(|req| req.matches(version))
-                    .unwrap_or(true)
-            })
+            .filter(|(version, _)| lua_package_req.version_req().matches(version))
             .flat_map(|(version, rock_types)| {
                 rock_types.iter().filter_map(move |rock_type| {
                     let include = match rock_type {

--- a/rocks-lib/src/operations/resolve.rs
+++ b/rocks-lib/src/operations/resolve.rs
@@ -8,10 +8,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     build::BuildBehaviour,
     config::Config,
-    lockfile::{
-        LocalPackageId, LocalPackageSpec, LockConstraint, Lockfile, LockfilePermissions,
-        PinnedState,
-    },
+    lockfile::{LocalPackageId, LocalPackageSpec, Lockfile, LockfilePermissions, PinnedState},
     package::PackageReq,
     progress::{MultiProgress, Progress},
     remote_package_db::RemotePackageDB,
@@ -63,11 +60,7 @@ where
                         .download_remote_rock()
                         .await?;
 
-                    let constraint = if let Some(package_req) = package.version_req() {
-                        LockConstraint::Constrained(package_req.clone())
-                    } else {
-                        LockConstraint::Unconstrained
-                    };
+                    let constraint = package.version_req().clone().into();
 
                     let dependencies = downloaded_rock
                         .rockspec()

--- a/rocks-lib/src/package/mod.rs
+++ b/rocks-lib/src/package/mod.rs
@@ -44,7 +44,7 @@ impl PackageSpec {
     pub fn into_package_req(self) -> PackageReq {
         PackageReq {
             name: self.name,
-            version_req: Some(self.version.into_version_req()),
+            version_req: self.version.into_version_req(),
         }
     }
 }
@@ -161,15 +161,18 @@ pub struct PackageReq {
     /// The name of the package.
     pub(crate) name: PackageName,
     /// The version requirement, for example "1.0.0" or ">=1.0.0".
-    pub(crate) version_req: Option<PackageVersionReq>,
+    pub(crate) version_req: PackageVersionReq,
 }
 
 impl PackageReq {
     pub fn new(name: String, version: Option<String>) -> Result<Self, PackageVersionReqError> {
+        let version_req = match version {
+            Some(version_req_str) => PackageVersionReq::parse(version_req_str.as_str())?,
+            None => PackageVersionReq::any(),
+        };
         Ok(Self {
             name: PackageName::new(name),
-            version_req: version
-                .map(|version_req_str| PackageVersionReq::parse(version_req_str.as_str()).unwrap()),
+            version_req,
         })
     }
     pub fn parse(pkg_constraints: &String) -> Result<Self, PackageReqParseError> {
@@ -178,27 +181,22 @@ impl PackageReq {
     pub fn name(&self) -> &PackageName {
         &self.name
     }
-    pub fn version_req(&self) -> Option<&PackageVersionReq> {
-        self.version_req.as_ref()
+    pub fn version_req(&self) -> &PackageVersionReq {
+        &self.version_req
     }
     /// Evaluate whether the given package satisfies the package requirement
     /// given by `self`.
     pub fn matches(&self, package: &PackageSpec) -> bool {
-        self.name == package.name
-            && self
-                .version_req
-                .as_ref()
-                .unwrap_or(&PackageVersionReq::any())
-                .matches(&package.version)
+        self.name == package.name && self.version_req.matches(&package.version)
     }
 }
 
 impl Display for PackageReq {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(version_req) = &self.version_req {
-            f.write_str(format!("{} {}", self.name, version_req).as_str())
-        } else {
+        if self.version_req.is_any() {
             self.name.fmt(f)
+        } else {
+            f.write_str(format!("{} {}", self.name, self.version_req).as_str())
         }
     }
 }
@@ -213,7 +211,7 @@ impl From<PackageName> for PackageReq {
     fn from(name: PackageName) -> Self {
         Self {
             name,
-            version_req: None,
+            version_req: PackageVersionReq::any(),
         }
     }
 }
@@ -300,13 +298,13 @@ impl FromStr for PackageReq {
 
         let constraints = str.trim_start_matches(&rock_name_str).trim();
         let version_req = match constraints {
-            "" => None,
-            constraints => Some(PackageVersionReq::parse(constraints.trim_start()).map_err(
-                |error| PackageReqParseError::InvalidPackageVersionReq {
+            "" => PackageVersionReq::any(),
+            constraints => PackageVersionReq::parse(constraints.trim_start()).map_err(|error| {
+                PackageReqParseError::InvalidPackageVersionReq {
                     error,
                     str: str.to_string(),
-                },
-            )?),
+                }
+            })?,
         };
         Ok(Self {
             name: PackageName::new(rock_name_str),

--- a/rocks-lib/src/package/outdated.rs
+++ b/rocks-lib/src/package/outdated.rs
@@ -11,10 +11,10 @@ use super::{version::PackageVersion, PackageName, PackageReq, PackageSpec, Packa
 pub struct RockNotFound(PackageName);
 
 #[derive(Error, Debug)]
-#[error("rock {} has no version that satisfies constraint {}", .name, .constraint.as_ref().map(|c| c.to_string()).unwrap_or("any".into()))]
+#[error("rock {} has no version that satisfies constraint {}", .name, .constraint.to_string())]
 pub struct RockConstraintUnsatisfied {
     name: PackageName,
-    constraint: Option<PackageVersionReq>,
+    constraint: PackageVersionReq,
 }
 
 impl PackageSpec {

--- a/rocks-lib/src/project/mod.rs
+++ b/rocks-lib/src/project/mod.rs
@@ -215,19 +215,20 @@ impl Project {
             | DependencyType::Build(ref deps)
             | DependencyType::Test(ref deps) => {
                 for dep in deps {
-                    table[dep.name().to_string()] = toml_edit::value(
-                        dep.version_req().map(|v| v.to_string()).unwrap_or(
-                            package_db
-                                .latest_version(dep.name())
-                                // This condition should never be reached, as the package should
-                                // have been found in the database or an error should have been
-                                // reported prior.
-                                // Still worth making an error message for this in the future,
-                                // though.
-                                .expect("unable to query latest version for package")
-                                .to_string(),
-                        ),
-                    );
+                    let dep_version_str = if dep.version_req().is_any() {
+                        package_db
+                            .latest_version(dep.name())
+                            // This condition should never be reached, as the package should
+                            // have been found in the database or an error should have been
+                            // reported prior.
+                            // Still worth making an error message for this in the future,
+                            // though.
+                            .expect("unable to query latest version for package")
+                            .to_string()
+                    } else {
+                        dep.version_req().to_string()
+                    };
+                    table[dep.name().to_string()] = toml_edit::value(dep_version_str);
                 }
             }
             DependencyType::External(ref deps) => {

--- a/rocks-lib/src/remote_package_db/mod.rs
+++ b/rocks-lib/src/remote_package_db/mod.rs
@@ -110,10 +110,7 @@ impl RemotePackageDB {
                                     elements
                                         .keys()
                                         .filter(|version| {
-                                            package_req
-                                                .version_req()
-                                                .map(|req| req.matches(version))
-                                                .unwrap_or(true)
+                                            package_req.version_req().matches(version)
                                         })
                                         .sorted_by(|a, b| Ord::cmp(b, a))
                                         .collect_vec(),

--- a/rocks-lib/src/rockspec/mod.rs
+++ b/rocks-lib/src/rockspec/mod.rs
@@ -100,11 +100,9 @@ impl<T: Rockspec> LuaVersionCompatibility for T {
             .collect_vec();
         let lua_pkg_version = lua_version.as_version();
         lua_version_reqs.is_empty()
-            || lua_version_reqs.into_iter().any(|lua| {
-                lua.version_req()
-                    .map(|req| req.matches(&lua_pkg_version))
-                    .unwrap_or(true)
-            })
+            || lua_version_reqs
+                .into_iter()
+                .any(|lua| lua.version_req().matches(&lua_pkg_version))
     }
 
     fn lua_version(&self) -> Option<LuaVersion> {
@@ -130,11 +128,7 @@ pub(crate) fn latest_lua_version(
                 ("5.2.0", LuaVersion::Lua52),
                 ("5.1.0", LuaVersion::Lua51),
             ] {
-                if lua
-                    .version_req()
-                    .map(|req| req.matches(&possibility.parse().unwrap()))
-                    .unwrap_or(true)
-                {
+                if lua.version_req().matches(&possibility.parse().unwrap()) {
                     return Some(version);
                 }
             }

--- a/rocks-lib/src/tree/mod.rs
+++ b/rocks-lib/src/tree/mod.rs
@@ -156,10 +156,7 @@ impl Tree {
                     .iter()
                     .rev()
                     .filter(|package| {
-                        req.version_req()
-                            .map(|req| req.matches(package.version()))
-                            .unwrap_or(true)
-                            && filter(package)
+                        req.version_req().matches(package.version()) && filter(package)
                     })
                     .map(|package| package.id())
                     .collect_vec();


### PR DESCRIPTION
Stacked on #369.
Closes #364.

This also changes the behaviour when installing with a `--dev` flag.
`foo >= <semver>` without an upper constraint no longer matches `<dev>`.
Only `Any` and `<dev>` can match `<dev>`, which I think will result in less surprises for users.
For example, `rocks --dev update` won't update semver packages to dev versions.