### PR TITLE
refactor!: improve API to prevent logic errors with Project lockfiles

### DIFF
--- a/rocks-bin/src/add.rs
+++ b/rocks-bin/src/add.rs
@@ -36,7 +36,6 @@ pub struct Add {
 
 pub async fn add(data: Add, config: Config) -> Result<()> {
     let mut project = Project::current()?.ok_or_eyre("No project found")?;
-    let lockfile = project.lockfile()?;
 
     let pin = PinnedState::from(data.pin);
     let tree = project.tree(&config)?;
@@ -89,7 +88,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
         .packages(test_packages)
         .pin(pin)
         .progress(MultiProgress::new_arc())
-        .lockfile(lockfile)
+        .project(&project)
         .install()
         .await?;
 

--- a/rocks-bin/src/add.rs
+++ b/rocks-bin/src/add.rs
@@ -84,7 +84,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
             .await?;
     }
 
-    operations::Install::new(&config)
+    operations::Install::new(&tree, &config)
         .packages(regular_packages)
         .packages(build_packages)
         .packages(test_packages)

--- a/rocks-bin/src/add.rs
+++ b/rocks-bin/src/add.rs
@@ -1,6 +1,6 @@
 use eyre::{OptionExt, Result};
 use rocks_lib::{
-    config::{Config, LuaVersion},
+    config::Config,
     lockfile::PinnedState,
     operations,
     package::PackageReq,
@@ -39,8 +39,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
     let lockfile = project.lockfile()?;
 
     let pin = PinnedState::from(data.pin);
-    let lua_version = LuaVersion::from(&config)?;
-    let tree = project.tree(lua_version)?;
+    let tree = project.tree(&config)?;
     let db = RemotePackageDB::from_config(&config, &Progress::Progress(ProgressBar::new())).await?;
 
     let regular_packages = apply_build_behaviour(data.package_req, pin, data.force, &tree);

--- a/rocks-bin/src/build.rs
+++ b/rocks-bin/src/build.rs
@@ -65,7 +65,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
         })
         .map(|dep| (BuildBehaviour::NoForce, dep.to_owned()));
 
-    Install::new(&config)
+    Install::new(&tree, &config)
         .packages(dependencies_to_install)
         .pin(pin)
         .package_db(package_db)
@@ -78,7 +78,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
             .wrap_err("error copying the project lockfile")?;
     }
 
-    build::Build::new(&rocks, &config, &progress.map(|p| p.new_bar()))
+    build::Build::new(&rocks, &tree, &config, &progress.map(|p| p.new_bar()))
         .pin(pin)
         .behaviour(BuildBehaviour::Force)
         .build()

--- a/rocks-bin/src/build.rs
+++ b/rocks-bin/src/build.rs
@@ -13,7 +13,7 @@ use rocks_lib::{
     progress::MultiProgress,
     project::Project,
     remote_package_db::RemotePackageDB,
-    rockspec::{LuaVersionCompatibility, Rockspec},
+    rockspec::Rockspec,
 };
 
 #[derive(Args, Default)]
@@ -45,9 +45,8 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
     };
 
     bar.map(|b| b.finish_and_clear());
+    let tree = project.tree(&config)?;
     let rocks = project.new_local_rockspec()?;
-    let lua_version = rocks.lua_version_matches(&config)?;
-    let tree = project.tree(lua_version)?;
 
     // Ensure all dependencies are installed first
     let dependencies = rocks

--- a/rocks-bin/src/check.rs
+++ b/rocks-bin/src/check.rs
@@ -11,7 +11,7 @@ use rocks_lib::{
 pub async fn check(config: Config) -> Result<()> {
     let project = Project::current()?.ok_or_eyre("Not in a project!")?;
 
-    Install::new(&config)
+    Install::new(&project.tree(LuaVersion::from(&config)?)?, &config)
         .package(BuildBehaviour::NoForce, "luacheck".parse()?)
         .pin(Pinned)
         .progress(MultiProgress::new_arc())

--- a/rocks-bin/src/check.rs
+++ b/rocks-bin/src/check.rs
@@ -1,7 +1,7 @@
 use eyre::{OptionExt, Result};
 use rocks_lib::{
     build::BuildBehaviour,
-    config::{Config, LuaVersion},
+    config::Config,
     lockfile::PinnedState::Pinned,
     operations::{Install, Run},
     progress::MultiProgress,
@@ -11,7 +11,7 @@ use rocks_lib::{
 pub async fn check(config: Config) -> Result<()> {
     let project = Project::current()?.ok_or_eyre("Not in a project!")?;
 
-    Install::new(&project.tree(LuaVersion::from(&config)?)?, &config)
+    Install::new(&project.tree(&config)?, &config)
         .package(BuildBehaviour::NoForce, "luacheck".parse()?)
         .pin(Pinned)
         .progress(MultiProgress::new_arc())
@@ -21,12 +21,7 @@ pub async fn check(config: Config) -> Result<()> {
     Run::new("luacheck", &config)
         .arg(project.root().to_string_lossy())
         .arg("--exclude-files")
-        .arg(
-            project
-                .tree(LuaVersion::from(&config)?)?
-                .root()
-                .to_string_lossy(),
-        )
+        .arg(project.tree(&config)?.root().to_string_lossy())
         .run()
         .await?;
 

--- a/rocks-bin/src/doc.rs
+++ b/rocks-bin/src/doc.rs
@@ -23,7 +23,7 @@ pub struct Doc {
 }
 
 pub async fn doc(args: Doc, config: Config) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
     let package_id = match tree.match_rocks(&args.package)? {
         RockMatches::NotFound(package_req) => {
             Err(eyre!("No package matching {} found.", package_req))

--- a/rocks-bin/src/info.rs
+++ b/rocks-bin/src/info.rs
@@ -6,7 +6,6 @@ use rocks_lib::{
     package::PackageReq,
     progress::{MultiProgress, Progress},
     rockspec::Rockspec,
-    tree::Tree,
 };
 
 #[derive(Args)]
@@ -15,8 +14,7 @@ pub struct Info {
 }
 
 pub async fn info(data: Info, config: Config) -> Result<()> {
-    // TODO(vhyrro): Add `Tree::from(&Config)`
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
 
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());

--- a/rocks-bin/src/install.rs
+++ b/rocks-bin/src/install.rs
@@ -5,7 +5,6 @@ use rocks_lib::{
     operations,
     package::PackageReq,
     progress::MultiProgress,
-    tree::Tree,
 };
 
 use crate::utils::install::apply_build_behaviour;
@@ -28,12 +27,12 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
     let pin = PinnedState::from(data.pin);
 
     let lua_version = LuaVersion::from(&config)?;
-    let tree = Tree::new(config.tree().clone(), lua_version)?;
+    let tree = config.tree(lua_version)?;
 
     let packages = apply_build_behaviour(data.package_req, pin, data.force, &tree);
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
-    operations::Install::new(&config)
+    operations::Install::new(&tree, &config)
         .packages(packages)
         .pin(pin)
         .progress(MultiProgress::new_arc())

--- a/rocks-bin/src/list.rs
+++ b/rocks-bin/src/list.rs
@@ -4,7 +4,6 @@ use itertools::Itertools as _;
 use rocks_lib::{
     config::{Config, LuaVersion},
     lockfile::PinnedState,
-    tree::Tree,
 };
 use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
 
@@ -15,7 +14,7 @@ pub struct ListCmd {
 }
 
 pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
     let available_rocks = tree.list()?;
 
     if list_data.porcelain {

--- a/rocks-bin/src/outdated.rs
+++ b/rocks-bin/src/outdated.rs
@@ -7,7 +7,6 @@ use rocks_lib::{
     config::{Config, LuaVersion},
     progress::{MultiProgress, Progress},
     remote_package_db::RemotePackageDB,
-    tree::Tree,
 };
 use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
 
@@ -20,7 +19,7 @@ pub struct Outdated {
 pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
     let progress = MultiProgress::new();
     let bar = Progress::Progress(progress.new_bar());
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
 
     let package_db = RemotePackageDB::from_config(&config, &bar).await?;
 

--- a/rocks-bin/src/pack.rs
+++ b/rocks-bin/src/pack.rs
@@ -66,12 +66,12 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
     };
     let result: Result<PathBuf> = match package_or_rockspec {
         PackageOrRockspec::Package(package_req) => {
-            let default_tree = Tree::new(config.tree().clone(), lua_version.clone())?;
+            let default_tree = config.tree(lua_version.clone())?;
             match default_tree.match_rocks(&package_req)? {
                 rocks_lib::tree::RockMatches::NotFound(_) => {
                     let temp_dir = TempDir::new("rocks-pack")?.into_path();
                     let tree = Tree::new(temp_dir.clone(), lua_version.clone())?;
-                    let packages = Install::new(&config)
+                    let packages = Install::new(&tree, &config)
                         .package(BuildBehaviour::Force, package_req)
                         .progress(progress)
                         .install()
@@ -118,7 +118,7 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let bar = progress.map(|p| p.new_bar());
             let tree = Tree::new(temp_dir.clone(), lua_version.clone())?;
             let config = config.with_tree(temp_dir);
-            let package = Build::new(&rockspec, &config, &bar).build().await?;
+            let package = Build::new(&rockspec, &tree, &config, &bar).build().await?;
             let rock_path = operations::Pack::new(dest_dir, tree, package).pack()?;
             Ok(rock_path)
         }

--- a/rocks-bin/src/path.rs
+++ b/rocks-bin/src/path.rs
@@ -5,7 +5,6 @@ use eyre::Result;
 use rocks_lib::{
     config::{Config, LuaVersion},
     path::{BinPath, PackagePath, Paths},
-    tree::Tree,
 };
 use strum::{EnumString, VariantNames};
 use strum_macros::Display;
@@ -74,7 +73,7 @@ impl Default for Shell {
 }
 
 pub async fn path(path_data: Path, config: Config) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
     let paths = Paths::from_tree(tree)?;
     let cmd = path_data.cmd.unwrap_or_default();
     let prepend = path_data.prepend;

--- a/rocks-bin/src/pin.rs
+++ b/rocks-bin/src/pin.rs
@@ -1,14 +1,11 @@
 use clap::Args;
 use eyre::eyre;
 use eyre::Result;
+use rocks_lib::config::{Config, LuaVersion};
 use rocks_lib::lockfile::PinnedState;
 use rocks_lib::operations;
 use rocks_lib::package::PackageSpec;
 use rocks_lib::tree::RockMatches;
-use rocks_lib::{
-    config::{Config, LuaVersion},
-    tree::Tree,
-};
 
 #[derive(Args)]
 pub struct ChangePin {
@@ -16,7 +13,7 @@ pub struct ChangePin {
 }
 
 pub fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
 
     match tree.match_rocks_and(&data.package.clone().into_package_req(), |package| {
         pin != package.pinned()

--- a/rocks-bin/src/purge.rs
+++ b/rocks-bin/src/purge.rs
@@ -3,11 +3,10 @@ use inquire::Confirm;
 use rocks_lib::{
     config::{Config, LuaVersion},
     progress::{MultiProgress, ProgressBar},
-    tree::Tree,
 };
 
 pub async fn purge(config: Config) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
 
     let len = tree.list()?.len();
 

--- a/rocks-bin/src/remove.rs
+++ b/rocks-bin/src/remove.rs
@@ -7,7 +7,7 @@ use rocks_lib::{
     config::{Config, LuaVersion},
     operations,
     package::PackageReq,
-    tree::{RockMatches, Tree},
+    tree::RockMatches,
 };
 
 // NOTE: This is currently functionally equivalent
@@ -21,7 +21,7 @@ pub struct Remove {
 }
 
 pub async fn remove(remove_args: Remove, config: Config) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
 
     let package_matches = remove_args
         .packages

--- a/rocks-bin/src/run.rs
+++ b/rocks-bin/src/run.rs
@@ -8,7 +8,6 @@ use rocks_lib::{
     path::Paths,
     project::Project,
     rockspec::LuaVersionCompatibility,
-    tree::Tree,
 };
 use which::which;
 
@@ -28,7 +27,7 @@ pub async fn run(run: Run, config: Config) -> Result<()> {
         Some(prj) => prj.rocks().lua_version_matches(&config)?,
         None => LuaVersion::from(&config)?,
     };
-    let tree = Tree::new(config.tree().clone(), lua_version.clone())?;
+    let tree = config.tree(lua_version)?;
     let paths = Paths::from_tree(tree)?;
     unsafe {
         // safe as long as this is single-threaded

--- a/rocks-bin/src/run_lua.rs
+++ b/rocks-bin/src/run_lua.rs
@@ -9,7 +9,6 @@ use rocks_lib::{
     path::Paths,
     project::Project,
     rockspec::LuaVersionCompatibility,
-    tree::Tree,
 };
 
 #[derive(Args, Default)]
@@ -55,7 +54,7 @@ pub async fn run_lua(run_lua: RunLua, config: Config) -> Result<()> {
             );
         }
     }
-    let tree = Tree::new(config.tree().clone(), lua_version.clone())?;
+    let tree = config.tree(lua_version)?;
     let paths = Paths::from_tree(tree)?;
     let status = match Command::new(&lua_cmd)
         .args(run_lua.args.unwrap_or_default())

--- a/rocks-bin/src/uninstall.rs
+++ b/rocks-bin/src/uninstall.rs
@@ -7,7 +7,7 @@ use rocks_lib::{
     config::{Config, LuaVersion},
     operations,
     package::PackageReq,
-    tree::{RockMatches, Tree},
+    tree::RockMatches,
 };
 
 #[derive(Args)]
@@ -17,7 +17,7 @@ pub struct Uninstall {
 }
 
 pub async fn uninstall(uninstall_args: Uninstall, config: Config) -> Result<()> {
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
 
     let package_matches = uninstall_args
         .packages

--- a/rocks-bin/src/update.rs
+++ b/rocks-bin/src/update.rs
@@ -3,7 +3,7 @@ use eyre::Result;
 use rocks_lib::config::LuaVersion;
 use rocks_lib::lockfile::PinnedState;
 use rocks_lib::progress::{MultiProgress, ProgressBar};
-use rocks_lib::{config::Config, operations, tree::Tree};
+use rocks_lib::{config::Config, operations};
 
 #[derive(Args)]
 pub struct Update {}
@@ -12,10 +12,10 @@ pub async fn update(config: Config) -> Result<()> {
     let progress = MultiProgress::new_arc();
     progress.map(|p| p.add(ProgressBar::from("🔎 Looking for updates...".to_string())));
 
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(&config)?)?;
+    let tree = config.tree(LuaVersion::from(&config)?)?;
     let lockfile = tree.lockfile()?;
 
-    operations::Update::new(&config)
+    operations::Update::new(&tree, &config)
         .packages(
             lockfile
                 .rocks()

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -48,6 +48,8 @@ pub struct Build<'a, R: Rockspec + HasIntegrity> {
     #[builder(start_fn)]
     rockspec: &'a R,
     #[builder(start_fn)]
+    tree: &'a Tree,
+    #[builder(start_fn)]
     config: &'a Config,
     #[builder(start_fn)]
     progress: &'a Progress<ProgressBar>,
@@ -248,7 +250,7 @@ async fn do_build<R: Rockspec + HasIntegrity>(
 
     let lua_version = build.rockspec.lua_version_matches(build.config)?;
 
-    let tree = Tree::new(build.config.tree().clone(), lua_version.clone())?;
+    let tree = build.tree;
 
     let temp_dir = tempdir::TempDir::new(&build.rockspec.package().to_string())?;
 

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -325,7 +325,7 @@ async fn do_build<R: Rockspec + HasIntegrity>(
 
             install(
                 build.rockspec,
-                &tree,
+                tree,
                 &output_paths,
                 &lua,
                 &build_dir,

--- a/rocks-lib/src/config/mod.rs
+++ b/rocks-lib/src/config/mod.rs
@@ -454,9 +454,7 @@ impl ConfigBuilder {
             namespace: self.namespace,
             lua_dir: self.lua_dir.unwrap_or_else(|| data_dir.join("lua")),
             lua_version,
-            tree: self
-                .tree
-                .unwrap_or_else(|| data_dir.join("tree")),
+            tree: self.tree.unwrap_or_else(|| data_dir.join("tree")),
             luarocks_tree: self.luarocks_tree.unwrap_or(data_dir.join(".luarocks")),
             no_project: self.no_project.unwrap_or(false),
             verbose: self.verbose.unwrap_or(false),

--- a/rocks-lib/src/config/mod.rs
+++ b/rocks-lib/src/config/mod.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use url::Url;
 
 use crate::rockspec::LuaVersionCompatibility;
+use crate::tree::Tree;
 use crate::{
     build::{
         utils,
@@ -238,9 +239,8 @@ impl Config {
         self.lua_version.as_ref()
     }
 
-    // TODO(vhyrro): Return `&Tree` instead
-    pub fn tree(&self) -> &PathBuf {
-        &self.tree
+    pub fn tree(&self, version: LuaVersion) -> io::Result<Tree> {
+        Tree::new(self.tree.clone(), version)
     }
 
     /// The tree in which to install luarocks for use as a compatibility layer

--- a/rocks-lib/src/config/mod.rs
+++ b/rocks-lib/src/config/mod.rs
@@ -456,15 +456,6 @@ impl ConfigBuilder {
             lua_version,
             tree: self
                 .tree
-                .or_else(|| {
-                    if self.no_project.unwrap_or(false) {
-                        None
-                    } else {
-                        current_project
-                            .as_ref()
-                            .map(|project| project.root().join(".rocks"))
-                    }
-                })
                 .unwrap_or_else(|| data_dir.join("tree")),
             luarocks_tree: self.luarocks_tree.unwrap_or(data_dir.join(".luarocks")),
             no_project: self.no_project.unwrap_or(false),

--- a/rocks-lib/src/luarocks/install_binary_rock.rs
+++ b/rocks-lib/src/luarocks/install_binary_rock.rs
@@ -23,7 +23,6 @@ use crate::{
     progress::{Progress, ProgressBar},
     remote_package_source::RemotePackageSource,
     rockspec::Rockspec,
-    tree::Tree,
 };
 
 use super::rock_manifest::RockManifestError;
@@ -102,7 +101,7 @@ impl<'a> BinaryRockInstall<'a> {
 
         let lua_version = rockspec.lua_version_matches(self.config)?;
 
-        let tree = Tree::new(self.config.tree().clone(), lua_version.clone())?;
+        let tree = self.config.tree(lua_version)?;
 
         let hashes = LocalPackageHashes {
             rockspec: rockspec.hash()?,
@@ -193,6 +192,7 @@ mod test {
         config::{ConfigBuilder, LuaVersion},
         operations::{unpack_rockspec, DownloadedPackedRockBytes, Pack, Remove},
         progress::MultiProgress,
+        tree::Tree,
     };
 
     use super::*;

--- a/rocks-lib/src/luarocks/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks/luarocks_installation.rs
@@ -107,7 +107,7 @@ impl LuaRocksInstallation {
 
         if !self.tree.match_rocks(&luarocks_req)?.is_found() {
             let rockspec = LuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap();
-            let pkg = Build::new(&rockspec, &self.config, progress)
+            let pkg = Build::new(&rockspec, &self.tree, &self.config, progress)
                 .constraint(luarocks_req.version_req().clone().into())
                 .build()
                 .await?;
@@ -172,9 +172,10 @@ impl LuaRocksInstallation {
                 )))
             });
             let config = self.config.clone();
+            let tree = self.tree.clone();
             tokio::spawn(async move {
                 let rockspec = install_spec.downloaded_rock.rockspec();
-                let pkg = Build::new(rockspec, &config, &bar)
+                let pkg = Build::new(rockspec, &tree, &config, &bar)
                     .constraint(install_spec.spec.constraint())
                     .behaviour(install_spec.build_behaviour)
                     .build()

--- a/rocks-lib/src/operations/install.rs
+++ b/rocks-lib/src/operations/install.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, io, sync::Arc};
 
 use crate::{
     build::{Build, BuildBehaviour, BuildError},
-    config::{Config, LuaVersionUnset},
+    config::{Config, LuaVersion, LuaVersionUnset},
     lockfile::{
         LocalPackage, LocalPackageId, LockConstraint, Lockfile, PinnedState, ReadOnly, ReadWrite,
     },
@@ -16,6 +16,7 @@ use crate::{
     },
     package::{PackageName, PackageReq},
     progress::{MultiProgress, Progress, ProgressBar},
+    project::Project,
     remote_package_db::{RemotePackageDB, RemotePackageDBError, RemotePackageDbIntegrityError},
     rockspec::Rockspec,
     tree::Tree,
@@ -40,7 +41,7 @@ pub struct Install<'a> {
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
     progress: Option<Arc<Progress<MultiProgress>>>,
-    lockfile: Option<Lockfile<ReadOnly>>,
+    project: Option<&'a Project>,
 }
 
 impl<'a> Install<'a> {
@@ -53,7 +54,7 @@ impl<'a> Install<'a> {
             packages: Vec::new(),
             pin: PinnedState::default(),
             progress: None,
-            lockfile: None,
+            project: None,
         }
     }
 
@@ -95,10 +96,10 @@ impl<'a> Install<'a> {
         }
     }
 
-    /// Pass a custom `Lockfile` to operate on.
-    pub fn lockfile(self, lockfile: Lockfile<ReadOnly>) -> Self {
+    /// Attach a project to the install phase (also affects the project's `rocks.lock`).
+    pub fn project(self, project: &'a Project) -> Self {
         Self {
-            lockfile: Some(lockfile),
+            project: Some(project),
             ..self
         }
     }
@@ -120,7 +121,7 @@ impl<'a> Install<'a> {
             self.packages,
             self.pin,
             package_db,
-            self.lockfile,
+            self.project,
             self.tree,
             self.config,
             progress,
@@ -157,14 +158,15 @@ async fn install(
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
     package_db: RemotePackageDB,
-    lockfile: Option<Lockfile<ReadOnly>>,
+    project: Option<&Project>,
     tree: &Tree,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackage>, InstallError>
 where
 {
-    let mut lockfile = lockfile.map_or_else(|| tree.lockfile(), Ok)?.write_guard();
+    let lockfile = config.tree(LuaVersion::from(config)?)?.lockfile()?;
+    let project_lockfile = project.map(|p| p.lockfile()).transpose()?;
 
     install_impl(
         packages,
@@ -172,19 +174,23 @@ where
         Arc::new(package_db),
         config,
         tree,
-        &mut lockfile,
+        lockfile,
+        project_lockfile,
         progress,
     )
     .await
 }
 
+// TODO(vhyrro): This function has too many arguments. Refactor it.
+#[allow(clippy::too_many_arguments)]
 async fn install_impl(
     packages: Vec<(BuildBehaviour, PackageReq)>,
     pin: PinnedState,
     package_db: Arc<RemotePackageDB>,
     config: &Config,
     tree: &Tree,
-    lockfile: &mut Lockfile<ReadWrite>,
+    mut lockfile: Lockfile<ReadOnly>,
+    project_lockfile: Option<Lockfile<ReadOnly>>,
     progress_arc: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackage>, InstallError> {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -269,23 +275,42 @@ async fn install_impl(
     .flatten()
     .try_collect::<_, HashMap<LocalPackageId, LocalPackage>, _>()?;
 
-    installed_packages.iter().for_each(|(id, pkg)| {
-        lockfile.add(pkg);
+    let write_dependency =
+        |lockfile: &mut Lockfile<ReadWrite>, id: &LocalPackageId, pkg: &LocalPackage| {
+            lockfile.add(pkg);
 
-        all_packages
-            .get(id)
-            .map(|pkg| pkg.spec.dependencies())
-            .unwrap_or_default()
-            .into_iter()
-            .for_each(|dependency_id| {
-                lockfile.add_dependency(
-                    pkg,
-                    installed_packages
-                        .get(dependency_id)
-                        .expect("required dependency not found"),
-                );
-            });
-    });
+            all_packages
+                .get(id)
+                .map(|pkg| pkg.spec.dependencies())
+                .unwrap_or_default()
+                .into_iter()
+                .for_each(|dependency_id| {
+                    lockfile.add_dependency(
+                        pkg,
+                        installed_packages
+                            .get(dependency_id)
+                            .expect("required dependency not found"),
+                    );
+                });
+        };
+
+    lockfile.map_then_flush(|lockfile| {
+        installed_packages
+            .iter()
+            .for_each(|(id, pkg)| write_dependency(lockfile, id, pkg));
+
+        Ok::<_, io::Error>(())
+    })?;
+
+    if let Some(mut project_lockfile) = project_lockfile {
+        project_lockfile.map_then_flush(|lockfile| {
+            installed_packages
+                .iter()
+                .for_each(|(id, pkg)| write_dependency(lockfile, id, pkg));
+
+            Ok::<_, io::Error>(())
+        })?;
+    }
 
     Ok(installed_packages.into_values().collect_vec())
 }

--- a/rocks-lib/src/operations/remove.rs
+++ b/rocks-lib/src/operations/remove.rs
@@ -66,7 +66,7 @@ impl<'a> Remove<'a> {
             Some(p) => p,
             None => MultiProgress::new_arc(),
         };
-        let tree = Tree::new(self.config.tree().clone(), LuaVersion::from(self.config)?)?;
+        let tree = self.config.tree(LuaVersion::from(self.config)?)?;
         remove(self.packages, tree, &Arc::clone(&progress)).await
     }
 }

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -90,7 +90,7 @@ async fn run_tests(test: Test<'_>) -> Result<(), RunTestsError> {
             .test_lua_version()
             .ok_or(RunTestsError::LuaVersionUnset),
     }?;
-    let tree = Tree::new(test.config.tree().clone(), lua_version)?;
+    let tree = test.config.tree(lua_version)?;
     // TODO(#204): Only ensure busted if running with busted (e.g. a .busted directory exists)
     ensure_busted(&tree, test.config, test.progress.clone()).await?;
     ensure_dependencies(&rocks, &tree, test.config, test.progress).await?;
@@ -150,7 +150,7 @@ pub async fn ensure_busted(
     let busted_req = PackageReq::new("busted".into(), None)?;
 
     if !tree.match_rocks(&busted_req)?.is_found() {
-        Install::new(config)
+        Install::new(tree, config)
             .package(BuildBehaviour::NoForce, busted_req)
             .progress(progress)
             .install()
@@ -186,7 +186,7 @@ async fn ensure_dependencies(
             build_behaviour.map(|it| (it, req.to_owned()))
         });
 
-    Install::new(config)
+    Install::new(tree, config)
         .packages(dependencies)
         .progress(progress)
         .install()

--- a/rocks-lib/src/operations/update.rs
+++ b/rocks-lib/src/operations/update.rs
@@ -11,6 +11,7 @@ use crate::{
     package::{PackageReq, RockConstraintUnsatisfied},
     progress::{MultiProgress, Progress},
     remote_package_db::{RemotePackageDB, RemotePackageDBError},
+    tree::Tree,
 };
 
 use super::{Install, InstallError, Remove, RemoveError};
@@ -21,6 +22,8 @@ use super::{Install, InstallError, Remove, RemoveError};
 #[derive(Builder)]
 #[builder(start_fn = new, finish_fn(name = _update, vis = ""))]
 pub struct Update<'a> {
+    #[builder(start_fn)]
+    tree: &'a Tree,
     #[builder(start_fn)]
     config: &'a Config,
 
@@ -66,6 +69,7 @@ impl<State: update_builder::State> UpdateBuilder<'_, State> {
         update(
             new_self.packages,
             package_db,
+            new_self.tree,
             new_self.config,
             new_self.progress,
         )
@@ -88,6 +92,7 @@ pub enum UpdateError {
 async fn update(
     packages: Vec<(LocalPackage, PackageReq)>,
     package_db: RemotePackageDB,
+    tree: &Tree,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<(), UpdateError> {
@@ -108,7 +113,7 @@ async fn update(
         println!("Nothing to update.");
         Ok(())
     } else {
-        Install::new(config)
+        Install::new(tree, config)
             .packages(
                 updatable
                     .iter()

--- a/rocks-lib/src/which/mod.rs
+++ b/rocks-lib/src/which/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     config::{Config, LuaVersion, LuaVersionUnset},
     lua_rockspec::LuaModule,
     package::PackageReq,
-    tree::Tree,
 };
 
 /// A rocks module finder.
@@ -57,7 +56,7 @@ pub enum WhichError {
 
 fn do_search(which: Which<'_>) -> Result<PathBuf, WhichError> {
     let config = which.config;
-    let tree = Tree::new(config.tree().clone(), LuaVersion::from(config)?)?;
+    let tree = config.tree(LuaVersion::from(config)?)?;
     let lockfile = tree.lockfile()?;
     let local_packages = if which.packages.is_empty() {
         lockfile

--- a/rocks-lib/tests/build.rs
+++ b/rocks-lib/tests/build.rs
@@ -37,7 +37,9 @@ async fn builtin_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(&rockspec, &config, &Progress::Progress(bar))
+    let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
+
+    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -63,7 +65,9 @@ async fn make_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(&rockspec, &config, &Progress::Progress(bar))
+    let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
+
+    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -115,7 +119,10 @@ async fn lockfile_update() {
         .await
         .unwrap();
     let package_db: RemotePackageDB = lockfile.into();
-    Install::new(&config)
+
+    let tree = project.tree(LuaVersion::from(&config).unwrap()).unwrap();
+
+    Install::new(&tree, &config)
         .packages(
             dependencies
                 .iter()
@@ -143,7 +150,9 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(&rockspec, &config, &Progress::Progress(bar))
+    let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
+
+    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await

--- a/rocks-lib/tests/build.rs
+++ b/rocks-lib/tests/build.rs
@@ -120,7 +120,7 @@ async fn lockfile_update() {
         .unwrap();
     let package_db: RemotePackageDB = lockfile.into();
 
-    let tree = project.tree(LuaVersion::from(&config).unwrap()).unwrap();
+    let tree = project.tree(&config).unwrap();
 
     Install::new(&tree, &config)
         .packages(


### PR DESCRIPTION
Simplifies the handling of Lua versions and tree configurations. This prevents stupid mistakes from happening where you try to operate on the user-wide tree but instead operate on the local project's tree because the default config would automatically assign the tree to the current project.

Each commit is a specific distinct aspect of this rewrite, but the first three commits do not produce a buildable rust project. I guess we'll want to squash + merge this after review.

- [x] Updated calls to `project.tree` and `config.tree` to remove the `LuaVersion` parameter and ensure the functions are called with the updated `config` object.