### PR TITLE
feat!: break apart `LuaVersion::from` into two subfunctions for more fine-grained behaviour control

### DIFF
--- a/lux-cli/src/doc.rs
+++ b/lux-cli/src/doc.rs
@@ -23,7 +23,7 @@ pub struct Doc {
 }
 
 pub async fn doc(args: Doc, config: Config) -> Result<()> {
-    let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
+    let tree = config.user_tree(LuaVersion::from_config(&config)?.clone())?;
     let package_id = match tree.match_rocks(&args.package)? {
         RockMatches::NotFound(package_req) => {
             Err(eyre!("No package matching {} found.", package_req))

--- a/lux-cli/src/exec.rs
+++ b/lux-cli/src/exec.rs
@@ -30,7 +30,7 @@ pub async fn exec(run: Exec, config: Config) -> Result<()> {
     let tree = match &project {
         Some(project) => project.tree(&config)?,
         None => {
-            let lua_version = LuaVersion::from(&config)?.clone();
+            let lua_version = LuaVersion::from_config(&config)?.clone();
             config.user_tree(lua_version)?
         }
     };

--- a/lux-cli/src/install.rs
+++ b/lux-cli/src/install.rs
@@ -27,7 +27,7 @@ pub struct Install {
 pub async fn install(data: Install, config: Config) -> Result<()> {
     let pin = PinnedState::from(data.pin);
 
-    let lua_version = LuaVersion::from(&config)?.clone();
+    let lua_version = LuaVersion::from_config(&config)?.clone();
     let tree = config.user_tree(lua_version)?;
 
     let packages = apply_build_behaviour(data.package_req, pin, data.force, &tree)?;

--- a/lux-cli/src/install_lua.rs
+++ b/lux-cli/src/install_lua.rs
@@ -6,7 +6,7 @@ use lux_lib::{
 };
 
 pub async fn install_lua(config: Config) -> Result<()> {
-    let version_stringified = &LuaVersion::from(&config)?;
+    let version_stringified = &LuaVersion::from_current_project_or_config(&config)?;
 
     let progress = MultiProgress::new(&config);
 

--- a/lux-cli/src/list.rs
+++ b/lux-cli/src/list.rs
@@ -15,7 +15,7 @@ pub struct ListCmd {
 
 /// List rocks that are installed in the user tree
 pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
-    let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
+    let tree = config.user_tree(LuaVersion::from_config(&config)?.clone())?;
     let available_rocks = tree.list()?;
 
     if list_data.porcelain {

--- a/lux-cli/src/outdated.rs
+++ b/lux-cli/src/outdated.rs
@@ -34,7 +34,7 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
             project.tree(&config)?
         }
         None => {
-            let lua_version = LuaVersion::from(&config)?.clone();
+            let lua_version = LuaVersion::from_config(&config)?.clone();
             config.user_tree(lua_version)?
         }
     };

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -64,7 +64,7 @@ pub struct Pack {
 }
 
 pub async fn pack(args: Pack, config: Config) -> Result<()> {
-    let lua_version = LuaVersion::from(&config)?.clone();
+    let lua_version = LuaVersion::from_current_project_or_config(&config)?;
     let dest_dir = std::env::current_dir()?;
     let progress = MultiProgress::new_arc(&config);
     let result: Result<PathBuf> = match args.package_or_rockspec {

--- a/lux-cli/src/pin.rs
+++ b/lux-cli/src/pin.rs
@@ -82,7 +82,7 @@ pub async fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState)
             }
         }
         None => {
-            let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
+            let tree = config.user_tree(LuaVersion::from_config(&config)?.clone())?;
 
             for package in &data.package {
                 match tree.match_rocks_and(package, |package| pin != package.pinned())? {

--- a/lux-cli/src/purge.rs
+++ b/lux-cli/src/purge.rs
@@ -7,7 +7,7 @@ use lux_lib::{
 
 /// Purge the user tree
 pub async fn purge(config: Config) -> Result<()> {
-    let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
+    let tree = config.user_tree(LuaVersion::from_config(&config)?.clone())?;
 
     let len = tree.list()?.len();
 

--- a/lux-cli/src/run_lua.rs
+++ b/lux-cli/src/run_lua.rs
@@ -12,7 +12,6 @@ use lux_lib::{
     operations,
     progress::MultiProgress,
     project::Project,
-    rockspec::LuaVersionCompatibility,
 };
 
 use crate::build::{self, Build};
@@ -54,7 +53,7 @@ pub async fn run_lua(run_lua: RunLua, config: Config) -> Result<()> {
     let project = Project::current()?;
     let (lua_version, root, tree, mut welcome_message) = match &project {
         Some(project) => (
-            project.toml().lua_version_matches(&config)?,
+            project.lua_version(&config)?,
             project.root().to_path_buf(),
             project.tree(&config)?,
             format!(
@@ -63,7 +62,7 @@ pub async fn run_lua(run_lua: RunLua, config: Config) -> Result<()> {
             ),
         ),
         None => {
-            let version = LuaVersion::from(&config)?.clone();
+            let version = LuaVersion::from_config(&config)?.clone();
             (
                 version.clone(),
                 std::env::current_dir()?,

--- a/lux-cli/src/uninstall.rs
+++ b/lux-cli/src/uninstall.rs
@@ -20,7 +20,7 @@ pub struct Uninstall {
 
 /// Uninstall one or multiple rocks from the user tree
 pub async fn uninstall(uninstall_args: Uninstall, config: Config) -> Result<()> {
-    let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
+    let tree = config.user_tree(LuaVersion::from_config(&config)?.clone())?;
 
     let package_matches = uninstall_args
         .packages
@@ -166,7 +166,7 @@ Reinstall?
 
     let mut has_dangling_rocks = true;
     while has_dangling_rocks {
-        let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
+        let tree = config.user_tree(LuaVersion::from_config(&config)?.clone())?;
         let lockfile = tree.lockfile()?;
         let dangling_rocks = lockfile
             .rocks()

--- a/lux-cli/src/utils/project.rs
+++ b/lux-cli/src/utils/project.rs
@@ -38,7 +38,7 @@ pub fn current_project_or_user_tree(config: &Config) -> Result<Tree> {
     Ok(match &project {
         Some(project) => project.tree(config)?,
         None => {
-            let lua_version = LuaVersion::from(config)?.clone();
+            let lua_version = LuaVersion::from_config(config)?.clone();
             config.user_tree(lua_version)?
         }
     })

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     remote_package_source::RemotePackageSource,
     tree::{RockLayout, Tree},
 };
-use bon::{builder, Builder};
+use bon::Builder;
 use builtin::BuiltinBuildError;
 use cmake::CMakeError;
 use command::CommandError;

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -53,7 +53,7 @@ impl BuildBackend for RustMluaBuildSpec {
         let config = args.config;
         let build_dir = args.build_dir;
         let progress = args.progress;
-        let lua_version = LuaVersion::from(config)?;
+        let lua_version = LuaVersion::from_current_project_or_config(config)?;
         let lua_feature = match lua_version {
             LuaVersion::Lua51 => "lua51",
             LuaVersion::Lua52 => "lua52",

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -99,7 +99,19 @@ impl LuaInstallation {
         config: &Config,
         progress: &Progress<ProgressBar>,
     ) -> Result<Self, LuaInstallationError> {
-        Self::new(LuaVersion::from(config)?, config, progress).await
+        Self::new(&LuaVersion::from_config(config)?, config, progress).await
+    }
+
+    pub async fn new_from_current_project_or_config(
+        config: &Config,
+        progress: &Progress<ProgressBar>,
+    ) -> Result<Self, LuaInstallationError> {
+        Self::new(
+            &LuaVersion::from_current_project_or_config(config)?,
+            config,
+            progress,
+        )
+        .await
     }
 
     pub async fn new(
@@ -545,7 +557,11 @@ mod test {
             println!("Skipping impure test");
             return;
         }
-        let config = ConfigBuilder::new().unwrap().build().unwrap();
+        let config = ConfigBuilder::new()
+            .unwrap()
+            .lua_version(Some(LuaVersion::from_detected().unwrap()))
+            .build()
+            .unwrap();
         let lua_version = config.lua_version().unwrap();
         let progress = MultiProgress::new(&config);
         let bar = progress.map(MultiProgress::new_bar);

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -245,7 +245,7 @@ mod test {
     use io::Read;
 
     use crate::{
-        config::ConfigBuilder,
+        config::{ConfigBuilder, LuaVersion},
         operations::{unpack_rockspec, DownloadedPackedRockBytes, Pack, Uninstall},
         progress::MultiProgress,
     };
@@ -280,7 +280,7 @@ mod test {
         let progress = MultiProgress::new(&config);
         let bar = progress.map(MultiProgress::new_bar);
         let tree = config
-            .user_tree(config.lua_version().unwrap().clone())
+            .user_tree(LuaVersion::from_config(&config).unwrap())
             .unwrap();
         let local_package = BinaryRockInstall::new(
             &rockspec,
@@ -342,7 +342,7 @@ mod test {
         let progress = MultiProgress::new(&config);
         let bar = progress.map(MultiProgress::new_bar);
         let tree = config
-            .user_tree(config.lua_version().unwrap().clone())
+            .user_tree(LuaVersion::from_config(&config).unwrap())
             .unwrap();
         let local_package = BinaryRockInstall::new(
             &rockspec,

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -228,7 +228,7 @@ variables = {{
 }}
 "#,
             lua_version_str,
-            LuaVersion::from(&self.config)?,
+            LuaVersion::from_current_project_or_config(&self.config)?,
             self.config.make_cmd(),
         );
         let luarocks_config_content =

--- a/lux-lib/src/manifest/mod.rs
+++ b/lux-lib/src/manifest/mod.rs
@@ -98,10 +98,11 @@ async fn get_manifest(
 /// if the cache doesn't exist or is outdated.
 async fn manifest_from_cache_or_server(
     server_url: &Url,
+    manifest_version: &LuaVersion,
     config: &Config,
     bar: &Progress<ProgressBar>,
 ) -> Result<String, ManifestFromServerError> {
-    let manifest_version = LuaVersion::from(config)?.version_compatibility_str();
+    let manifest_version = manifest_version.version_compatibility_str();
     let url = mk_manifest_url(server_url, &manifest_version, config)?;
 
     // Stores a path to the manifest cache (this allows us to operate on a manifest without
@@ -153,10 +154,11 @@ async fn manifest_from_cache_or_server(
 /// This still populates the cache.
 pub(crate) async fn manifest_from_server_only(
     server_url: &Url,
+    manifest_version: &LuaVersion,
     config: &Config,
     bar: &Progress<ProgressBar>,
 ) -> Result<String, ManifestFromServerError> {
-    let manifest_version = LuaVersion::from(config)?.version_compatibility_str();
+    let manifest_version = manifest_version.version_compatibility_str();
     let url = mk_manifest_url(server_url, &manifest_version, config)?;
     let cache = mk_manifest_cache(&url, config).await?;
     let client = Client::new();
@@ -324,14 +326,26 @@ impl Manifest {
         config: &Config,
         progress: &Progress<ProgressBar>,
     ) -> Result<Self, ManifestError> {
-        let content =
-            crate::manifest::manifest_from_cache_or_server(&server_url, config, progress).await?;
+        let manifest_version = LuaVersion::from_current_project_or_config(config)
+            .map_err(|err| ManifestError::Server(err.into()))?;
+
+        let content = crate::manifest::manifest_from_cache_or_server(
+            &server_url,
+            &manifest_version,
+            config,
+            progress,
+        )
+        .await?;
         match ManifestMetadata::new(&content) {
             Ok(metadata) => Ok(Self::new(server_url, metadata)),
             Err(_) => {
-                let manifest =
-                    crate::manifest::manifest_from_server_only(&server_url, config, progress)
-                        .await?;
+                let manifest = crate::manifest::manifest_from_server_only(
+                    &server_url,
+                    &manifest_version,
+                    config,
+                    progress,
+                )
+                .await?;
                 Ok(Self::new(server_url, ManifestMetadata::new(&manifest)?))
             }
         }
@@ -415,7 +429,7 @@ mod tests {
     use httptest::{matchers::request, responders::status_code, Expectation, Server};
     use serial_test::serial;
 
-    use crate::{config::ConfigBuilder, package::PackageReq, progress::MultiProgress};
+    use crate::{config::ConfigBuilder, package::PackageReq};
 
     use super::*;
 
@@ -457,11 +471,14 @@ mod tests {
             .no_progress(Some(true))
             .build()
             .unwrap();
-        let progress = MultiProgress::new(&config);
-        let bar = progress.map(MultiProgress::new_bar);
-        manifest_from_cache_or_server(&Url::parse(&url_str).unwrap(), &config, &bar)
-            .await
-            .unwrap();
+        manifest_from_cache_or_server(
+            &Url::parse(&url_str).unwrap(),
+            &LuaVersion::LuaJIT,
+            &config,
+            &Progress::no_progress(),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -479,12 +496,15 @@ mod tests {
             .no_progress(Some(true))
             .build()
             .unwrap();
-        let progress = MultiProgress::new(&config);
-        let bar = progress.map(MultiProgress::new_bar);
 
-        manifest_from_cache_or_server(&Url::parse(&url_str).unwrap(), &config, &bar)
-            .await
-            .unwrap();
+        manifest_from_cache_or_server(
+            &Url::parse(&url_str).unwrap(),
+            &LuaVersion::Lua51,
+            &config,
+            &Progress::no_progress(),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -508,11 +528,14 @@ mod tests {
             .no_progress(Some(true))
             .build()
             .unwrap();
-        let progress = MultiProgress::new(&config);
-        let bar = progress.map(MultiProgress::new_bar);
-        let result = manifest_from_cache_or_server(&Url::parse(&url_str).unwrap(), &config, &bar)
-            .await
-            .unwrap();
+        let result = manifest_from_cache_or_server(
+            &Url::parse(&url_str).unwrap(),
+            &LuaVersion::Lua51,
+            &config,
+            &Progress::no_progress(),
+        )
+        .await
+        .unwrap();
         assert_eq!(result, manifest_content);
     }
 

--- a/lux-lib/src/operations/build_project.rs
+++ b/lux-lib/src/operations/build_project.rs
@@ -93,9 +93,11 @@ impl<State: build_project_builder::State + build_project_builder::IsComplete>
             .collect_vec();
 
         let build_tree = project.build_tree(config)?;
-        let lua =
-            LuaInstallation::new_from_config(config, &progress.map(|progress| progress.new_bar()))
-                .await?;
+        let lua = LuaInstallation::new_from_current_project_or_config(
+            config,
+            &progress.map(|progress| progress.new_bar()),
+        )
+        .await?;
         let luarocks = LuaRocksInstallation::new(config, build_tree.clone())?;
 
         if args.no_lock {

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -103,7 +103,7 @@ async fn exec(run: Exec<'_>) -> Result<(), ExecError> {
         .project
         .map(|project| project.lua_version(run.config))
         .transpose()?
-        .unwrap_or(LuaVersion::from(run.config)?.clone());
+        .unwrap_or(LuaVersion::from_config(run.config)?.clone());
 
     if let Some(project) = run.project {
         BuildProject::new(project, run.config)
@@ -169,7 +169,7 @@ async fn install_command(command: &str, config: &Config) -> Result<(), InstallCo
         tree::EntryType::Entrypoint,
     )
     .build();
-    let tree = config.user_tree(LuaVersion::from(config)?.clone())?;
+    let tree = config.user_tree(LuaVersion::from_config(config)?.clone())?;
     Install::new(config)
         .package(install_spec)
         .tree(tree)

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -12,7 +12,7 @@ use crate::luarocks::rock_manifest::RockManifestLua;
 use crate::luarocks::rock_manifest::RockManifestRoot;
 use crate::tree::RockLayout;
 use crate::tree::Tree;
-use bon::{builder, Builder};
+use bon::Builder;
 use clean_path::Clean;
 use itertools::Itertools;
 use std::collections::HashMap;

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -14,7 +14,7 @@ use crate::{
     rockspec::Rockspec,
     tree::{self, TreeError},
 };
-use bon::{builder, Builder};
+use bon::Builder;
 use itertools::Itertools;
 use thiserror::Error;
 
@@ -207,9 +207,8 @@ async fn do_sync(
 
     let packages_to_install = to_add
         .iter()
-        .cloned()
         .map(|(entry_type, pkg)| {
-            PackageInstallSpec::new(pkg.clone().into_package_req(), entry_type)
+            PackageInstallSpec::new(pkg.clone().into_package_req(), *entry_type)
                 .build_behaviour(BuildBehaviour::Force)
                 .pin(pkg.pinned())
                 .opt(pkg.opt())
@@ -242,12 +241,7 @@ async fn do_sync(
         }
     }
 
-    let packages_to_remove = report
-        .removed
-        .iter()
-        .cloned()
-        .map(|pkg| pkg.id())
-        .collect_vec();
+    let packages_to_remove = report.removed.iter().map(|pkg| pkg.id()).collect_vec();
 
     Uninstall::new()
         .config(args.config)

--- a/lux-lib/src/operations/uninstall.rs
+++ b/lux-lib/src/operations/uninstall.rs
@@ -66,7 +66,7 @@ where
         };
         let tree = args.tree.unwrap_or(
             args.config
-                .user_tree(LuaVersion::from(args.config)?.clone())?,
+                .user_tree(LuaVersion::from_config(args.config)?.clone())?,
         );
         remove(args.packages, tree, args.config, &Arc::clone(&progress)).await
     }

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -242,7 +242,7 @@ async fn update_install_tree(
 ) -> Result<Vec<LocalPackage>, UpdateError> {
     let tree = args
         .config
-        .user_tree(LuaVersion::from(args.config)?.clone())?;
+        .user_tree(LuaVersion::from_current_project_or_config(args.config)?.clone())?;
     let lockfile = tree.lockfile()?;
     let packages = updatable_packages(&lockfile)
         .into_iter()

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -493,7 +493,7 @@ impl LuaVersionCompatibility for PartialProjectToml {
     }
 
     fn lua_version_matches(&self, config: &Config) -> Result<LuaVersion, LuaVersionError> {
-        let version = LuaVersion::from(config)?.clone();
+        let version = LuaVersion::from_config(config)?.clone();
         if self.supports_lua_version(&version) {
             Ok(version)
         } else {

--- a/lux-lib/src/rockspec/mod.rs
+++ b/lux-lib/src/rockspec/mod.rs
@@ -101,7 +101,7 @@ impl<T: Rockspec> LuaVersionCompatibility for T {
     }
 
     fn lua_version_matches(&self, config: &Config) -> Result<LuaVersion, LuaVersionError> {
-        let version = LuaVersion::from(config)?.clone();
+        let version = LuaVersion::from_config(config)?.clone();
         if self.supports_lua_version(&version) {
             Ok(version)
         } else {

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -1,6 +1,6 @@
 use std::{io, path::PathBuf};
 
-use bon::{builder, Builder};
+use bon::Builder;
 use itertools::Itertools;
 use thiserror::Error;
 
@@ -59,7 +59,7 @@ pub enum WhichError {
 
 fn do_search(which: Which<'_>) -> Result<PathBuf, WhichError> {
     let config = which.config;
-    let lua_version = LuaVersion::from(config)?;
+    let lua_version = LuaVersion::from_config(config)?;
     let tree = config.user_tree(lua_version.clone())?;
     let lockfile = tree.lockfile()?;
     let local_packages = if which.packages.is_empty() {

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -109,8 +109,8 @@ async fn cmake_build() {
 async fn command_build() {
     // The rockspec appears to be broken when using luajit headers on macos
     let config = ConfigBuilder::new().unwrap().build().unwrap();
-    let lua_version = LuaVersion::from(&config).unwrap_or(&LuaVersion::Lua51);
-    if cfg!(target_os = "macos") && *lua_version == LuaVersion::LuaJIT {
+    let lua_version = LuaVersion::from_config(&config).unwrap_or(LuaVersion::Lua51);
+    if cfg!(target_os = "macos") && lua_version == LuaVersion::LuaJIT {
         println!("luaposix is broken on macos/luajit! Skipping...");
         return;
     }
@@ -185,7 +185,7 @@ async fn treesitter_parser_build() {
         .unwrap();
 
     let tree = config
-        .user_tree(LuaVersion::from(&config).unwrap().clone())
+        .user_tree(LuaVersion::from_config(&config).unwrap().clone())
         .unwrap();
 
     Build::new()
@@ -316,7 +316,7 @@ fn test_build_multiple_treesitter_parsers() {
             .unwrap();
 
         let tree = config
-            .user_tree(LuaVersion::from(&config).unwrap().clone())
+            .user_tree(LuaVersion::from_config(&config).unwrap().clone())
             .unwrap();
 
         let config = config.clone();

--- a/lux-lib/tests/install.rs
+++ b/lux-lib/tests/install.rs
@@ -68,7 +68,7 @@ async fn test_install(install_spec: PackageInstallSpec) {
         .unwrap();
 
     let tree = config
-        .user_tree(LuaVersion::from(&config).unwrap().clone())
+        .user_tree(LuaVersion::from_config(&config).unwrap().clone())
         .unwrap();
     let installed = Install::new(&config)
         .package(install_spec)

--- a/lux-lib/tests/luarocks_installation.rs
+++ b/lux-lib/tests/luarocks_installation.rs
@@ -39,10 +39,10 @@ async fn luarocks_make() {
     let build_dir = TempDir::new().unwrap();
     build_dir.copy_from(&project_root, &["**"]).unwrap();
     let dest_dir = TempDir::new().unwrap();
-    let lua_version = LuaVersion::from(&config).unwrap_or(&LuaVersion::Lua51);
+    let lua_version = LuaVersion::from_config(&config).unwrap_or(LuaVersion::Lua51);
     let progress = MultiProgress::new(&config);
-    let bar = progress.map(MultiProgress::new_bar);
-    let lua = LuaInstallation::new(lua_version, &config, &bar)
+    let bar = progress.map(|p| p.new_bar());
+    let lua = LuaInstallation::new(&lua_version, &config, &bar)
         .await
         .unwrap();
     luarocks


### PR DESCRIPTION
This PR changes the `LuaVersion::from` function into two distinct functions - one that gets the current version just based off of the currently installed Lua binary, the other one which checks the current project's lux.toml in order to determine the expected version.

Setting this as draft, I still need to test if the CLI has properly benefitted from these changes.