### PR TITLE
feat(build)!: more output in verbose mode

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -47,6 +47,10 @@ async fn main() -> Result<()> {
 
     let config = config_builder.build()?;
 
+    if config.verbose() {
+        std::env::set_var("CC_ENABLE_DEBUG_OUTPUT", "1");
+    }
+
     match cli.command {
         Commands::Completion(completion_args) => completion::completion(completion_args).await?,
         Commands::Search(search_data) => search::search(search_data, config).await?,

--- a/lux-lib/src/build/cmake.rs
+++ b/lux-lib/src/build/cmake.rs
@@ -152,7 +152,7 @@ impl BuildBackend for CMakeBuildSpec {
 async fn spawn_cmake_cmd(cmd: &mut Command, config: &Config) -> Result<(), CMakeError> {
     match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
         Ok(child) => match child.wait_with_output().await {
-            Ok(output) if output.status.success() => {}
+            Ok(output) if output.status.success() => utils::log_command_output(&output, config),
             Ok(output) => {
                 return Err(CMakeError::CommandFailure {
                     name: config.cmake_cmd().clone(),

--- a/lux-lib/src/build/command.rs
+++ b/lux-lib/src/build/command.rs
@@ -131,7 +131,7 @@ async fn run_command(
             })
         }
         Ok(child) => match child.wait_with_output().await {
-            Ok(output) if output.status.success() => {}
+            Ok(output) if output.status.success() => utils::log_command_output(&output, config),
             Ok(output) => {
                 return Err(CommandError::CommandFailure {
                     command: substituted_cmd,

--- a/lux-lib/src/build/make.rs
+++ b/lux-lib/src/build/make.rs
@@ -93,7 +93,9 @@ impl BuildBackend for MakeBuildSpec {
                 .spawn()
             {
                 Ok(child) => match child.wait_with_output().await {
-                    Ok(output) if output.status.success() => {}
+                    Ok(output) if output.status.success() => {
+                        utils::log_command_output(&output, config)
+                    }
                     Ok(output) => {
                         return Err(MakeError::CommandFailure {
                             name: match self.build_target {
@@ -143,7 +145,7 @@ impl BuildBackend for MakeBuildSpec {
                 .output()
                 .await
             {
-                Ok(output) if output.status.success() => {}
+                Ok(output) if output.status.success() => utils::log_command_output(&output, config),
                 Ok(output) => {
                     return Err(MakeError::CommandFailure {
                         name: format!("{} {}", config.make_cmd(), self.install_target),

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -82,7 +82,7 @@ pub enum OutputValidationError {
     },
 }
 
-fn validate_output(output: Output) -> Result<(), OutputValidationError> {
+fn validate_output(output: &Output) -> Result<(), OutputValidationError> {
     if !output.status.success() {
         return Err(OutputValidationError::CommandFailure {
             status: output.status,
@@ -212,7 +212,8 @@ pub(crate) async fn compile_c_files(
         }
     }
 
-    validate_output(output)?;
+    validate_output(&output)?;
+    log_command_output(&output, config);
 
     if output_path.exists() {
         Ok(())
@@ -454,7 +455,8 @@ pub(crate) async fn compile_c_modules(
         }
     }
 
-    validate_output(output)?;
+    validate_output(&output)?;
+    log_command_output(&output, config);
 
     if output_path.exists() {
         Ok(())
@@ -509,6 +511,18 @@ pub(crate) async fn install_binary(
     set_executable_permissions(&script).await?;
 
     Ok(script)
+}
+
+/// Logs the output's stdout and stderr in verbose mode
+pub(crate) fn log_command_output(output: &Output, config: &Config) {
+    if config.verbose() {
+        if !output.stderr.is_empty() {
+            println!("{}", String::from_utf8_lossy(&output.stderr));
+        }
+        if !output.stdout.is_empty() {
+            println!("{}", String::from_utf8_lossy(&output.stdout));
+        }
+    }
 }
 
 async fn install_wrapped_binary(

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tokio::process::Command;
 
 use crate::{
-    build::BuildError,
+    build::{self, BuildError},
     config::{Config, LuaVersion, LuaVersionUnset},
     lua_installation::LuaInstallation,
     lua_rockspec::RockspecFormat,
@@ -298,6 +298,7 @@ variables = {{
             .output()
             .await?;
         if output.status.success() {
+            build::utils::log_command_output(&output, &self.config);
             Ok(())
         } else {
             Err(ExecLuaRocksError::CommandFailure {


### PR DESCRIPTION
Closes #854.

@teto @Freed-Wu please feel free to open a new issue if you realise there is something else that needs to be printed in verbose mode.

This also fixes `lx exec` to always be verbose.