### PR TITLE
fix: don't download remote manifest if is there is nothing to install

### DIFF
--- a/lux-lib/src/operations/install/mod.rs
+++ b/lux-lib/src/operations/install/mod.rs
@@ -95,6 +95,9 @@ where
     /// Install the packages.
     pub async fn install(self) -> Result<Vec<LocalPackage>, InstallError> {
         let install_built = self._build();
+        if install_built.packages.is_empty() {
+            return Ok(Vec::default());
+        }
         let progress = match install_built.progress {
             Some(p) => p,
             None => MultiProgress::new_arc(install_built.config),

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -96,6 +96,14 @@ impl<State: update_builder::State> UpdateBuilder<'_, State> {
     {
         let args = self._update();
 
+        if args
+            .packages
+            .as_ref()
+            .is_some_and(|packages| packages.is_empty())
+        {
+            return Ok(Vec::default());
+        }
+
         let progress = args
             .progress
             .clone()


### PR DESCRIPTION
Closes #1059.