### PR TITLE
build(nix): add lua5_4 to all devShells for compilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
               buildInputs =
                 extra_pkgs
                 ++ (with pkgs; [
+                  lua5_4 # Needed for compilation
                   rust-analyzer
                   ra-multiplex
                   cargo-nextest


### PR DESCRIPTION
lux fails to compile if lua 5.4 isn't available.
So this PR adds it to all devShells.
The Lua passed into `mkDevShell` appears first on the `PATH`.