### PR TITLE
feat!: use `org.lumenlabs.lux` as identifier

### DIFF
--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -243,7 +243,7 @@ pub struct Config {
 
 impl Config {
     pub fn get_project_dirs() -> Result<ProjectDirs, NoValidHomeDirectory> {
-        directories::ProjectDirs::from("org", "neorocks", "lux").ok_or(NoValidHomeDirectory)
+        directories::ProjectDirs::from("org", "lumenlabs", "lux").ok_or(NoValidHomeDirectory)
     }
 
     pub fn get_default_cache_path() -> Result<PathBuf, NoValidHomeDirectory> {
@@ -437,8 +437,8 @@ impl ConfigBuilder {
 
     /// Get the path to the lux config file.
     pub fn config_file() -> Result<PathBuf, NoValidHomeDirectory> {
-        let project_dirs =
-            directories::ProjectDirs::from("org", "neorocks", "lux").ok_or(NoValidHomeDirectory)?;
+        let project_dirs = directories::ProjectDirs::from("org", "lumenlabs", "lux")
+            .ok_or(NoValidHomeDirectory)?;
         Ok(project_dirs.config_dir().join("config.toml").to_path_buf())
     }
 

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -743,7 +743,7 @@ mod tests {
             license = 'MIT',
             homepage = 'https://github.com/lumen-oss/rocks.nvim',
             issues_url = 'https://github.com/lumen-oss/rocks.nvim/issues',
-            maintainer = 'neorocks',
+            maintainer = 'Lumen Labs',
         }\n
         source = {\n
             url = 'https://github.com/lumen-oss/rocks.nvim/archive/1.0.0/rocks.nvim.zip',\n
@@ -760,7 +760,7 @@ mod tests {
             license: Some("MIT".into()),
             homepage: Some(Url::parse("https://github.com/lumen-oss/rocks.nvim").unwrap()),
             issues_url: Some("https://github.com/lumen-oss/rocks.nvim/issues".into()),
-            maintainer: Some("neorocks".into()),
+            maintainer: Some("Lumen Labs".into()),
             labels: Vec::new(),
         };
         assert_eq!(rockspec.local.description, expected_description);
@@ -774,7 +774,7 @@ mod tests {
             license = 'MIT',
             homepage = 'https://github.com/lumen-oss/rocks.nvim',
             issues_url = 'https://github.com/lumen-oss/rocks.nvim/issues',
-            maintainer = 'neorocks',
+            maintainer = 'Lumen Labs',
             labels = {},
         }\n
         external_dependencies = { FOO = { library = 'foo' } }\n
@@ -793,7 +793,7 @@ mod tests {
             license: Some("MIT".into()),
             homepage: Some(Url::parse("https://github.com/lumen-oss/rocks.nvim").unwrap()),
             issues_url: Some("https://github.com/lumen-oss/rocks.nvim/issues".into()),
-            maintainer: Some("neorocks".into()),
+            maintainer: Some("Lumen Labs".into()),
             labels: Vec::new(),
         };
         assert_eq!(rockspec.local.description, expected_description);
@@ -819,7 +819,7 @@ mod tests {
             license = 'MIT',
             homepage = 'https://github.com/lumen-oss/rocks.nvim',
             issues_url = 'https://github.com/lumen-oss/rocks.nvim/issues',
-            maintainer = 'neorocks',
+            maintainer = 'Lumen Labs',
             labels = { 'package management', },
         }\n
         supported_platforms = { 'unix', '!windows' }\n
@@ -843,7 +843,7 @@ mod tests {
             license: Some("MIT".into()),
             homepage: Some(Url::parse("https://github.com/lumen-oss/rocks.nvim").unwrap()),
             issues_url: Some("https://github.com/lumen-oss/rocks.nvim/issues".into()),
-            maintainer: Some("neorocks".into()),
+            maintainer: Some("Lumen Labs".into()),
             labels: vec!["package management".into()],
         };
         assert_eq!(rockspec.local.description, expected_description);

--- a/lux.toml
+++ b/lux.toml
@@ -3,7 +3,7 @@ lua = ">=5.1"
 
 [description]
 summary = "The Lua API for the lux package manager"
-maintainer = "neorocks"
+maintainer = "Lumen Labs"
 homepage = "https://lux.lumen-labs.org"
 issues_url = "https://github.com/lumen-oss/lux/issues"
 labels = ["luarocks", "lux", "package-manager", "packagemanager", "build"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -316,7 +316,7 @@ fn dist_package() -> Result<(), DynError> {
         .homepage("https://lux.lumen-labs.org")
         .authors(vec!["mrcjkb", "vhyrro"])
         .publisher("lumen-oss")
-        .identifier("org.neorocks.lux")
+        .identifier("org.lumenlabs.lux")
         .license_file(project_root.join("LICENSE"))
         .icons(icons)
         .appimage(AppImageConfig::new().files(file_mappings))


### PR DESCRIPTION
... instead of `org.neorocks.lux`.

This is a **BREAKING CHANGE**, because the location of configs and cache, data directories, etc. might change.