### PR TITLE
feat: Add `lx debug dependencies` subcommand

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use lux_cli::{
     add, build, check, completion, config,
     debug::Debug,
-    doc, download, exec, fetch, format, generate_rockspec, info, install, install_lua,
+    dependencies, doc, download, exec, fetch, format, generate_rockspec, info, install, install_lua,
     install_rockspec, lint, list, outdated, pack, path, pin, project, purge, remove, run, run_lua,
     search, shell, test, uninstall, unpack, update,
     upload::{self},
@@ -71,6 +71,7 @@ async fn main() -> Result<()> {
             Debug::Unpack(unpack_data) => unpack::unpack(unpack_data, config).await?,
             Debug::UnpackRemote(unpack_data) => unpack::unpack_remote(unpack_data, config).await?,
             Debug::Project(debug_project) => project::debug_project(debug_project)?,
+            Debug::Dependencies(deps_args) => dependencies::check_dependencies(deps_args)?,
         },
         Commands::New(project_data) => project::write_project_rockspec(project_data).await?,
         Commands::Build(build_data) => {

--- a/lux-cli/src/debug.rs
+++ b/lux-cli/src/debug.rs
@@ -2,7 +2,20 @@ use crate::{
     project::DebugProject,
     unpack::{Unpack, UnpackRemote},
 };
-use clap::Subcommand;
+use clap::{Args, Subcommand};
+
+#[derive(Args)]
+pub struct Dependencies {
+    /// Output format: human-readable or json
+    #[arg(long, default_value = "human")]
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, clap::ValueEnum)]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
 
 #[derive(Subcommand)]
 pub enum Debug {
@@ -14,4 +27,6 @@ pub enum Debug {
     UnpackRemote(UnpackRemote),
     /// View information about the current project.
     Project(DebugProject),
+    /// Check for required dependencies (C compiler, make, cmake, cargo, pkg-config).
+    Dependencies(Dependencies),
 }

--- a/lux-cli/src/dependencies.rs
+++ b/lux-cli/src/dependencies.rs
@@ -1,0 +1,58 @@
+use crate::debug::{Dependencies, OutputFormat};
+use eyre::Result;
+use lux_lib::dependencies::DependencyReport;
+
+pub fn check_dependencies(args: Dependencies) -> Result<()> {
+    let report = DependencyReport::generate();
+
+    match args.format {
+        OutputFormat::Human => print_human_readable(&report),
+        OutputFormat::Json => print_json(&report)?,
+    }
+
+    Ok(())
+}
+
+fn print_human_readable(report: &DependencyReport) {
+    println!("Dependency Check Report");
+    println!("=======================\n");
+
+    print_dependency(&report.c_compiler);
+    print_dependency(&report.make);
+    print_dependency(&report.cmake);
+    print_dependency(&report.cargo);
+    print_dependency(&report.pkg_config);
+
+    println!("\nSummary:");
+    let total = 5;
+    let found = [
+        &report.c_compiler,
+        &report.make,
+        &report.cmake,
+        &report.cargo,
+        &report.pkg_config,
+    ]
+    .iter()
+    .filter(|d| d.found)
+    .count();
+
+    println!("  Found: {}/{}", found, total);
+    println!("  Missing: {}/{}", total - found, total);
+}
+
+fn print_dependency(dep: &lux_lib::dependencies::DependencyStatus) {
+    let status = if dep.found { "✓" } else { "✗" };
+    let status_text = if dep.found { "Found" } else { "Not found" };
+
+    print!("{} {}: {}", status, dep.name, status_text);
+    if let Some(path) = &dep.path {
+        print!(" ({})", path.display());
+    }
+    println!();
+}
+
+fn print_json(report: &DependencyReport) -> Result<()> {
+    let json = serde_json::to_string_pretty(report)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -40,6 +40,7 @@ pub mod check;
 pub mod completion;
 pub mod config;
 pub mod debug;
+pub mod dependencies;
 pub mod doc;
 pub mod download;
 pub mod exec;

--- a/lux-lib/src/dependencies.rs
+++ b/lux-lib/src/dependencies.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use which::which;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DependencyStatus {
+    pub name: String,
+    pub found: bool,
+    pub path: Option<PathBuf>,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DependencyReport {
+    pub c_compiler: DependencyStatus,
+    pub make: DependencyStatus,
+    pub cmake: DependencyStatus,
+    pub cargo: DependencyStatus,
+    pub pkg_config: DependencyStatus,
+}
+
+impl DependencyReport {
+    pub fn generate() -> Self {
+        Self {
+            c_compiler: check_c_compiler(),
+            make: check_executable("make"),
+            cmake: check_executable("cmake"),
+            cargo: check_executable("cargo"),
+            pkg_config: check_executable("pkg-config"),
+        }
+    }
+}
+
+fn check_executable(name: &str) -> DependencyStatus {
+    match which(name) {
+        Ok(path) => DependencyStatus {
+            name: name.to_string(),
+            found: true,
+            path: Some(path),
+            version: None,
+        },
+        Err(_) => DependencyStatus {
+            name: name.to_string(),
+            found: false,
+            path: None,
+            version: None,
+        },
+    }
+}
+
+fn check_c_compiler() -> DependencyStatus {
+    // Try common C compilers in order of preference
+    let compilers = vec!["cc", "gcc", "clang"];
+
+    for compiler in compilers {
+        if let Ok(path) = which(compiler) {
+            return DependencyStatus {
+                name: format!("C compiler ({})", compiler),
+                found: true,
+                path: Some(path),
+                version: None,
+            };
+        }
+    }
+
+    DependencyStatus {
+        name: "C compiler".to_string(),
+        found: false,
+        path: None,
+        version: None,
+    }
+}

--- a/lux-lib/src/lib.rs
+++ b/lux-lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod config;
+pub mod dependencies;
 pub mod git;
 pub mod hash;
 pub mod lockfile;


### PR DESCRIPTION
## Summary
Implements a new `lx debug dependencies` subcommand that checks for required build tools and dependencies.

## Motivation
As requested in #1188, this provides users with a quick way to verify whether they have all the necessary dependencies installed for building Lua rocks.

## Changes Made

### 1. New Module: `lux-lib/src/dependencies.rs`
- Added `DependencyReport` struct to hold dependency check results
- Added `DependencyStatus` struct for individual dependency information
- Implemented `generate()` method that checks for:
  - C compiler toolchain (tries cc, gcc, clang in order)
  - make
  - cmake
  - cargo
  - pkg-config
- Uses the existing `which` crate to locate executables

### 2. CLI Integration: `lux-cli/src/debug.rs`
- Added `Dependencies` variant to the `Debug` enum
- Added `OutputFormat` enum supporting human-readable and JSON output
- Added command-line argument for format selection

### 3. Handler Implementation: `lux-cli/src/dependencies.rs`
- Created `check_dependencies()` function to handle the command
- Implemented `print_human_readable()` for user-friendly output with:
  - Status indicators (✓/✗)
  - Dependency names
  - File paths when found
  - Summary showing found vs missing count
- Implemented `print_json()` for machine-readable output

### 4. Binary Integration: `lux-cli/src/bin/lx.rs`
- Added handler in the `Debug` match arm
- Added import for dependencies module

## Usage Examples

### Human-readable output (default):
```bash
$ lx debug dependencies
Dependency Check Report
=======================

✓ C compiler (cc): Found (/usr/bin/cc)
✓ make: Found (/usr/bin/make)
✓ cmake: Found (/usr/bin/cmake)
✓ cargo: Found (/home/user/.cargo/bin/cargo)
✗ pkg-config: Not found

Summary:
  Found: 4/5
  Missing: 1/5
```

### JSON output:
```bash
$ lx debug dependencies --format json
{
  "c_compiler": {
    "name": "C compiler (cc)",
    "found": true,
    "path": "/usr/bin/cc",
    "version": null
  },
  "make": {
    "name": "make",
    "found": true,
    "path": "/usr/bin/make",
    "version": null
  },
  ...
}
```

## Design Decisions

- **Used existing `which` crate**: Already in workspace dependencies, no new deps needed
- **C compiler detection**: Tries multiple common compilers (cc, gcc, clang) for better compatibility
- **Dual output format**: Human-readable for interactive use, JSON for scripting
- **Extensible structure**: Easy to add more dependencies or version detection in the future
- **Non-blocking**: All checks are independent, failure of one doesn't affect others

## Testing Notes
- Code structure follows existing patterns in the codebase
- Implementation tested locally

Fixes #1188