### PR TITLE
feat: luarc dependency overrides

### DIFF
--- a/lux-lib/src/rockspec/lua_dependency.rs
+++ b/lux-lib/src/rockspec/lua_dependency.rs
@@ -24,6 +24,8 @@ pub struct LuaDependencySpec {
     pub(crate) pin: PinnedState,
     pub(crate) opt: OptState,
     pub(crate) source: Option<RockSourceSpec>,
+    /// Optional LuaLS library overrides to include in .luarc.json
+    pub(crate) luarc: Option<Vec<String>>, 
 }
 
 impl LuaDependencySpec {
@@ -38,6 +40,9 @@ impl LuaDependencySpec {
     }
     pub fn source(&self) -> &Option<RockSourceSpec> {
         &self.source
+    }
+    pub fn luarc(&self) -> &Option<Vec<String>> {
+        &self.luarc
     }
     pub fn into_package_req(self) -> PackageReq {
         self.package_req
@@ -60,6 +65,7 @@ impl From<PackageName> for LuaDependencySpec {
             pin: PinnedState::default(),
             opt: OptState::default(),
             source: None,
+            luarc: None,
         }
     }
 }
@@ -71,6 +77,7 @@ impl From<PackageReq> for LuaDependencySpec {
             pin: PinnedState::default(),
             opt: OptState::default(),
             source: None,
+            luarc: None,
         }
     }
 }
@@ -85,6 +92,7 @@ impl FromStr for LuaDependencySpec {
             pin: PinnedState::default(),
             opt: OptState::default(),
             source: None,
+            luarc: None,
         })
     }
 }
@@ -140,6 +148,7 @@ impl FromLua for LuaDependencySpec {
             pin: PinnedState::default(),
             opt: OptState::default(),
             source: None,
+            luarc: None,
         })
     }
 }
@@ -155,6 +164,7 @@ impl<'de> Deserialize<'de> for LuaDependencySpec {
             pin: PinnedState::default(),
             opt: OptState::default(),
             source: None,
+            luarc: None,
         })
     }
 }


### PR DESCRIPTION
### PR Summary

This change works as intended for me, but please confirm whether this approach feels necessary.
I’m happy to add specs or update the docs if we decide to merge it.

---

### Context

```toml
[test_dependencies.busted_intellisense]
git = "github:LuaCATS/busted"
version = "5ed85d0e016a5eb5eca097aa52905eedf1b180f1"
```

Currently produces a `luarc.json` entry hard-coded to **src**:

```json
".lux/5.1/test_dependencies/5.1/3b7...5-luassert_intellisense@d352...9-1/src"
```

However, this directory is empty for LuaCATS repositories, which keep their type definitions in `/library`. In our luarocks stub structure, that path is categorized as **etc** (`...9-1/etc`).

---

### Solution

This adds optional support for specifying the `.luarc` subdirectory in `lux.toml`:

```toml
[test_dependencies.busted_intellisense]
git = "github:LuaCATS/busted"
version = "5ed85d0e016a5eb5eca097aa52905eedf1b180f1"
luarc = "etc"
```

Now the generated `luarc.json` entry correctly points to **etc**:

```json
".lux/5.1/test_dependencies/5.1/3b7...5-luassert_intellisense@d352...9-1/etc"
```

---

### Notes

This works across dependency types. The `luarc` field name can be a little confusing for git dependencies, which are probably the main use case. It asks for a luarock-style subpath in a plain git source, so it can look odd (“what’s `/etc` in my repo?”). Since this mainly targets our Git pseudo luarock stubs, the tradeoff feels reasonable as long as we add a short note under “Git Dependencies” in the docs.

---

### LLM Disclosure

I worked through the problem myself and used GPT-5 to draft the Rust implementation. We stumbled a couple of times before landing on something that made sense to me. IANARD, but I really like its type system.