### PR TITLE
refactor!: disallow panic, expect and unwrap

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,3 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true

--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -74,3 +74,8 @@ gpgme = ["lux-lib/gpgme"]
 vendored = ["lux-lib/vendored"]
 vendored-lua = ["lux-lib/vendored-lua"]
 ssh-tests = ["lux-lib/ssh-tests"]
+
+[lints.clippy]
+panic = "warn"
+unwrap_used = "warn"
+expect_used = "warn"

--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -28,8 +28,7 @@ async fn main() -> Result<()> {
         }
     });
 
-    let mut config_builder = ConfigBuilder::new()
-        .unwrap()
+    let mut config_builder = ConfigBuilder::new()?
         .dev(Some(cli.dev))
         .extra_servers(cli.extra_servers)
         .generate_luarc(Some(!cli.no_luarc))
@@ -100,9 +99,7 @@ async fn main() -> Result<()> {
         Commands::Config(config_cmd) => config::config(config_cmd, config)?,
         Commands::Doc(doc_args) => doc::doc(doc_args, config).await?,
         Commands::Pack(pack_args) => pack::pack(pack_args, config).await?,
-        Commands::Uninstall(uninstall_data) => {
-            uninstall::uninstall(uninstall_data, config).await.unwrap()
-        }
+        Commands::Uninstall(uninstall_data) => uninstall::uninstall(uninstall_data, config).await?,
         Commands::Which(which_args) => which::which(which_args, config)?,
         Commands::Run(run_args) => run::run(run_args, config).await?,
         Commands::GenerateRockspec(data) => generate_rockspec::generate_rockspec(data)?,

--- a/lux-cli/src/config.rs
+++ b/lux-cli/src/config.rs
@@ -1,4 +1,4 @@
-use eyre::{eyre, Result};
+use eyre::{eyre, Context, OptionExt, Result};
 use inquire::Confirm;
 use lux_lib::config::{Config, ConfigBuilder};
 
@@ -34,9 +34,13 @@ pub fn config(cmd: ConfigCmd, config: Config) -> Result<()> {
                 || Confirm::new("Config already exists. Overwrite?")
                     .with_default(false)
                     .prompt()
-                    .expect("Error prompting to overwrite config")
+                    .wrap_err("error prompting to overwrite config")?
             {
-                std::fs::create_dir_all(config_file.parent().unwrap())?;
+                std::fs::create_dir_all(
+                    config_file
+                        .parent()
+                        .ok_or_eyre("error getting lux config parent directory")?,
+                )?;
                 let content = if init.default {
                     let cfg: ConfigBuilder = ConfigBuilder::default().build()?.into();
                     toml::to_string(&cfg)?

--- a/lux-cli/src/install_lua.rs
+++ b/lux-cli/src/install_lua.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{OptionExt, Result};
 use lux_lib::{
     config::{Config, LuaVersion},
     lua_installation::LuaInstallation,
@@ -23,7 +23,7 @@ pub async fn install_lua(config: Config) -> Result<()> {
         .includes()
         .first()
         .and_then(|dir| dir.parent())
-        .expect("error getting parent directory");
+        .ok_or_eyre("error getting lua include parent directory")?;
 
     bar.map(|bar| {
         bar.finish_with_message(format!(

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -85,7 +85,7 @@ struct NewProjectValidated {
 
 fn clap_parse_license(s: &str) -> std::result::Result<LicenseId, String> {
     match validate_license(s) {
-        Ok(Validation::Valid) => Ok(parse_license_unchecked(s)),
+        Ok(Validation::Valid) => unsafe { Ok(parse_license_unchecked(s)) },
         Err(_) | Ok(Validation::Invalid(_)) => {
             Err(format!("unable to identify license {s}, please try again!"))
         }
@@ -110,13 +110,13 @@ fn clap_parse_list(input: &str) -> std::result::Result<Vec<String>, String> {
     }
 }
 
-/// Parses a license and panics upon failure.
+/// Parses a license.
 ///
 /// # Security
 ///
-/// This should only be invoked after validating the license with [`validate_license`].
-fn parse_license_unchecked(input: &str) -> LicenseId {
-    spdx::imprecise_license_id(input).unwrap().0
+/// WARNING: This should only be invoked after validating the license with [`validate_license`].
+unsafe fn parse_license_unchecked(input: &str) -> LicenseId {
+    spdx::imprecise_license_id(input).unwrap_unchecked().0
 }
 
 fn validate_license(input: &str) -> std::result::Result<Validation, Box<dyn Error + Send + Sync>> {
@@ -231,7 +231,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject) -> Result<()> {
                             .as_str()
                         {
                             "none" => None,
-                            license => Some(parse_license_unchecked(license)),
+                            license => unsafe { Some(parse_license_unchecked(license)) },
                         },
                     )
                 },

--- a/lux-cli/src/search.rs
+++ b/lux-cli/src/search.rs
@@ -48,7 +48,7 @@ pub async fn search(data: Search, config: Config) -> Result<()> {
                 tree.push(version.to_string());
             }
 
-            println!("{}", tree.to_string_with_format(&formatting).unwrap());
+            println!("{}", tree.to_string_with_format(&formatting)?);
         }
     }
 

--- a/lux-cli/src/shell.rs
+++ b/lux-cli/src/shell.rs
@@ -33,7 +33,7 @@ pub async fn shell(data: Shell, config: Config) -> Result<()> {
         return Err(eyre!("Already in a Lux shell."));
     }
 
-    let tree = current_project_or_user_tree(&config).unwrap();
+    let tree = current_project_or_user_tree(&config)?;
 
     let path = if data.build {
         let build_tree_path = tree.build_tree(&config)?;

--- a/lux-cli/src/uninstall.rs
+++ b/lux-cli/src/uninstall.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use eyre::{eyre, Result};
+use eyre::{eyre, Context, Result};
 use inquire::Confirm;
 use itertools::Itertools;
 use lux_lib::{
@@ -123,7 +123,7 @@ Reinstall?
         if Confirm::new(&prompt)
             .with_default(false)
             .prompt()
-            .expect("Error prompting for reinstall")
+            .wrap_err("Error prompting for reinstall")?
         {
             operations::Uninstall::new()
                 .config(&config)

--- a/lux-cli/src/upload.rs
+++ b/lux-cli/src/upload.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use eyre::Result;
+use eyre::{OptionExt, Result};
 use lux_lib::{
     config::Config, progress::MultiProgress, project::Project, remote_package_db::RemotePackageDB,
     upload::ProjectUpload,
@@ -18,7 +18,7 @@ pub struct Upload {
 
 #[cfg(feature = "gpgme")]
 pub async fn upload(data: Upload, config: Config) -> Result<()> {
-    let project = Project::current()?.unwrap();
+    let project = Project::current()?.ok_or_eyre("No project found")?;
 
     let progress = MultiProgress::new(&config);
     let bar = progress.map(MultiProgress::new_bar);
@@ -37,7 +37,7 @@ pub async fn upload(data: Upload, config: Config) -> Result<()> {
 
 #[cfg(not(feature = "gpgme"))]
 pub async fn upload(_data: Upload, config: Config) -> Result<()> {
-    let project = Project::current()?.unwrap();
+    let project = Project::current()?.ok_or_eyre("No project found")?;
     let progress = MultiProgress::new(&config);
     let bar = progress.map(MultiProgress::new_bar);
     let package_db = RemotePackageDB::from_config(&config, &bar).await?;

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -107,3 +107,8 @@ vendored-openssl = ["openssl/vendored"]
 vendored-libgit2 = ["git2/vendored-libgit2"]
 vendored-lua = ["mlua/vendored"]
 ssh-tests = []
+
+[lints.clippy]
+panic = "warn"
+unwrap_used = "warn"
+expect_used = "warn"

--- a/lux-lib/src/build/external_dependency.rs
+++ b/lux-lib/src/build/external_dependency.rs
@@ -353,7 +353,7 @@ fn format_linker_arg(arg: &str, compiler: &cc::Tool) -> String {
 }
 
 pub(crate) fn to_lib_name(file: &Path) -> String {
-    let file_name = file.file_name().unwrap();
+    let file_name = file.file_name().unwrap_or_default();
     if cfg!(target_family = "unix") {
         file_name
             .to_string_lossy()

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -374,18 +374,22 @@ where
                         .clone()
                         .or(source_metadata.archive_name());
                     if dir_entries.len() == 1
-                        && archive_name.is_some_and(|archive_name| {
+                        && archive_name.is_some_and(|archive_name| unsafe {
                             archive_name.to_string_lossy().starts_with(
                                 &dir_entries
                                     .first()
-                                    .unwrap()
+                                    .unwrap_unchecked()
                                     .file_name()
                                     .to_string_lossy()
                                     .to_string(),
                             )
                         })
                     {
-                        temp_dir.path().join(dir_entries.first().unwrap().path())
+                        unsafe {
+                            temp_dir
+                                .path()
+                                .join(dir_entries.first().unwrap_unchecked().path())
+                        }
                     } else {
                         temp_dir.path().into()
                     }

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -64,13 +64,15 @@ pub enum LuaVersionError {
 
 impl LuaVersion {
     pub fn as_version(&self) -> PackageVersion {
-        match self {
-            LuaVersion::Lua51 => "5.1.0".parse().unwrap(),
-            LuaVersion::Lua52 => "5.2.0".parse().unwrap(),
-            LuaVersion::Lua53 => "5.3.0".parse().unwrap(),
-            LuaVersion::Lua54 => "5.4.0".parse().unwrap(),
-            LuaVersion::LuaJIT => "5.1.0".parse().unwrap(),
-            LuaVersion::LuaJIT52 => "5.2.0".parse().unwrap(),
+        unsafe {
+            match self {
+                LuaVersion::Lua51 => "5.1.0".parse().unwrap_unchecked(),
+                LuaVersion::Lua52 => "5.2.0".parse().unwrap_unchecked(),
+                LuaVersion::Lua53 => "5.3.0".parse().unwrap_unchecked(),
+                LuaVersion::Lua54 => "5.4.0".parse().unwrap_unchecked(),
+                LuaVersion::LuaJIT => "5.1.0".parse().unwrap_unchecked(),
+                LuaVersion::LuaJIT52 => "5.2.0".parse().unwrap_unchecked(),
+            }
         }
     }
     pub fn version_compatibility_str(&self) -> String {
@@ -82,15 +84,17 @@ impl LuaVersion {
         }
     }
     pub fn as_version_req(&self) -> PackageVersionReq {
-        format!("~> {}", self.version_compatibility_str())
-            .parse()
-            .unwrap()
+        unsafe {
+            format!("~> {}", self.version_compatibility_str())
+                .parse()
+                .unwrap_unchecked()
+        }
     }
 
     /// Get the LuaVersion from a version that has been parsed from the `lua -v` output
     pub fn from_version(version: PackageVersion) -> Result<LuaVersion, LuaVersionError> {
         // NOTE: Special case. luajit -v outputs 2.x.y as a version
-        let luajit_version_req: PackageVersionReq = "~> 2".parse().unwrap();
+        let luajit_version_req: PackageVersionReq = unsafe { "~> 2".parse().unwrap_unchecked() };
         if luajit_version_req.matches(&version) {
             Ok(LuaVersion::LuaJIT)
         } else if LuaVersion::Lua51.as_version_req().matches(&version) {
@@ -573,9 +577,9 @@ impl ConfigBuilder {
 
         Ok(Config {
             enable_development_packages: self.enable_development_packages.unwrap_or(false),
-            server: self
-                .server
-                .unwrap_or_else(|| Url::parse("https://luarocks.org/").unwrap()),
+            server: self.server.unwrap_or_else(|| unsafe {
+                Url::parse("https://luarocks.org/").unwrap_unchecked()
+            }),
             extra_servers: self.extra_servers.unwrap_or_default(),
             only_sources: self.only_sources,
             namespace: self.namespace,

--- a/lux-lib/src/lua.rs
+++ b/lux-lib/src/lua.rs
@@ -1,15 +1,19 @@
 //! Special utilities for the Lua bridge.
 
-use std::sync::OnceLock;
-
 use tokio::runtime::{Builder, Runtime};
 
-pub fn lua_runtime() -> &'static Runtime {
-    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| {
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref LUA_RUNTIME: Runtime = {
+        #[allow(clippy::expect_used)]
         Builder::new_multi_thread()
             .enable_all()
             .build()
-            .expect("Failed to create a new runtime")
-    })
+            .expect("Failed to initialise Lua runtime")
+    };
+}
+
+pub fn lua_runtime() -> &'static Runtime {
+    &LUA_RUNTIME
 }

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -175,9 +175,9 @@ impl LuaInstallation {
                 .as_ref()
                 .and_then(|lib_dir| get_lua_lib_name(lib_dir, version));
             info.lib_name = lua_lib_name;
-            Some(Self {
+            dependency_info.map(|dependency_info| Self {
                 version: version.clone(),
-                dependency_info: dependency_info.unwrap(),
+                dependency_info,
                 bin,
             })
         } else {

--- a/lux-lib/src/lua_rockspec/build/builtin.rs
+++ b/lux-lib/src/lua_rockspec/build/builtin.rs
@@ -239,7 +239,7 @@ impl PartialOverride for ModuleSpecInternal {
 }
 
 #[derive(Error, Debug)]
-#[error("could not resolve platform override for `build.modules`. This is a bug!")]
+#[error("could not resolve platform override for `build.modules`. THIS IS A BUG!")]
 pub struct BuildModulesPlatformOverride;
 
 impl PlatformOverridable for ModuleSpecInternal {

--- a/lux-lib/src/lua_rockspec/build/mod.rs
+++ b/lux-lib/src/lua_rockspec/build/mod.rs
@@ -323,9 +323,7 @@ impl LuaPathBufTable {
                     LuaTableKey::IntKey(_) => value
                         .with_extension("")
                         .file_name()
-                        .unwrap_or_else(|| {
-                            panic!("unable to determine base name of {0}", value.display())
-                        })
+                        .unwrap_or_default()
                         .to_string_lossy()
                         .to_string(),
                     LuaTableKey::StringKey(key) => key,
@@ -350,9 +348,7 @@ impl LibPathBufTable {
                 let key = match key {
                     LuaTableKey::IntKey(_) => value
                         .file_name()
-                        .unwrap_or_else(|| {
-                            panic!("unable to determine base name of {0}", value.display())
-                        })
+                        .unwrap_or_default()
                         .to_string_lossy()
                         .to_string(),
                     LuaTableKey::StringKey(key) => key,
@@ -1002,11 +998,13 @@ impl BuildType {
             | &BuildType::None
             | &BuildType::LuaRock(_)
             | &BuildType::Source => None,
-            &BuildType::RustMlua => Some(
-                PackageReq::parse("luarocks-build-rust-mlua >= 0.2.5")
-                    .expect("error parsing luarocks-build-rust-mlua package requirement [This is a bug!]")
-                    .into(),
-            ),
+            &BuildType::RustMlua => unsafe {
+                Some(
+                    PackageReq::parse("luarocks-build-rust-mlua >= 0.2.5")
+                        .unwrap_unchecked()
+                        .into(),
+                )
+            },
             &BuildType::TreesitterParser => {
                 Some(PackageName::new("luarocks-build-treesitter-parser".into()).into())
             } // IMPORTANT: If adding another luarocks build backend,

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -347,7 +347,7 @@ impl RemoteLuaRockspec {
         source_spec: RockSourceSpec,
     ) -> Self {
         let version = package_spec.version().clone();
-        let rockspec_format: RockspecFormat = "3.0".into();
+        let rockspec_format = RockspecFormat::default();
         let raw_content = format!(
             r#"
 rockspec_format = "{}"
@@ -609,13 +609,14 @@ impl UserData for RockDescription {
 #[error("invalid rockspec format: {0}")]
 pub struct InvalidRockspecFormat(String);
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RockspecFormat {
     #[serde(rename = "1.0")]
     _1_0,
     #[serde(rename = "2.0")]
     _2_0,
     #[serde(rename = "3.0")]
+    #[default]
     _3_0,
 }
 
@@ -629,12 +630,6 @@ impl FromStr for RockspecFormat {
             "3.0" => Ok(Self::_3_0),
             txt => Err(InvalidRockspecFormat(txt.to_string())),
         }
-    }
-}
-
-impl From<&str> for RockspecFormat {
-    fn from(s: &str) -> Self {
-        Self::from_str(s).unwrap()
     }
 }
 
@@ -714,7 +709,7 @@ mod tests {
         "
         .to_string();
         let rockspec = RemoteLuaRockspec::new(&rockspec_content).unwrap();
-        assert_eq!(rockspec.local.rockspec_format, Some("1.0".into()));
+        assert_eq!(rockspec.local.rockspec_format, Some(RockspecFormat::_1_0));
         assert_eq!(rockspec.local.package, "foo".into());
         assert_eq!(rockspec.local.version, "1.0.0-1".parse().unwrap());
         assert_eq!(rockspec.local.description, RockDescription::default());

--- a/lux-lib/src/lua_rockspec/serde_util.rs
+++ b/lux-lib/src/lua_rockspec/serde_util.rs
@@ -17,9 +17,13 @@ impl<'de> Deserialize<'de> for LuaTableKey {
     {
         let value = serde_json::Value::deserialize(deserializer)?;
         if value.is_u64() {
-            Ok(LuaTableKey::IntKey(value.as_u64().unwrap()))
+            unsafe { Ok(LuaTableKey::IntKey(value.as_u64().unwrap_unchecked())) }
         } else if value.is_string() {
-            Ok(LuaTableKey::StringKey(value.as_str().unwrap().into()))
+            unsafe {
+                Ok(LuaTableKey::StringKey(
+                    value.as_str().unwrap_unchecked().into(),
+                ))
+            }
         } else {
             Err(de::Error::custom(format!(
                 "Could not parse Lua table key. Expected an integer or string, but got {value}"
@@ -41,7 +45,7 @@ where
 {
     let values = serde_json::Value::deserialize(deserializer)?;
     if values.is_string() {
-        let value = T::from(values.as_str().unwrap().into());
+        let value = unsafe { T::from(values.as_str().unwrap_unchecked().into()) };
         Ok(vec![value])
     } else {
         mlua_json_value_to_vec(values).map_err(de::Error::custom)

--- a/lux-lib/src/lua_rockspec/test_spec.rs
+++ b/lux-lib/src/lua_rockspec/test_spec.rs
@@ -128,11 +128,13 @@ impl ValidatedTestSpec {
 
     fn test_dependencies(&self) -> Vec<PackageReq> {
         match self {
-            Self::Busted(_) => vec![PackageReq::new("busted".into(), None).unwrap()],
-            Self::BustedNlua(_) => vec![
-                PackageReq::new("busted".into(), None).unwrap(),
-                PackageReq::new("nlua".into(), None).unwrap(),
-            ],
+            Self::Busted(_) => unsafe { vec![PackageReq::new_unchecked("busted".into(), None)] },
+            Self::BustedNlua(_) => unsafe {
+                vec![
+                    PackageReq::new_unchecked("busted".into(), None),
+                    PackageReq::new_unchecked("nlua".into(), None),
+                ]
+            },
             Self::Command(_) => Vec::new(),
             Self::LuaScript(_) => Vec::new(),
         }

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -224,7 +224,9 @@ async fn install_manifest_entries<T>(
         if src_path.is_dir() {
             recursive_copy_dir(&src_path, &target).await?;
         } else if src_path.is_file() {
-            tokio::fs::create_dir_all(target.parent().unwrap()).await?;
+            if let Some(target_parent_dir) = target.parent() {
+                tokio::fs::create_dir_all(target_parent_dir).await?;
+            }
             tokio::fs::copy(src.join(relative_src_path), target).await?;
         } else {
             let metadata = tokio::fs::metadata(&src_path).await?;

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -121,10 +121,10 @@ impl LuaRocksInstallation {
         let mut lockfile = self.tree.lockfile()?.write_guard();
 
         let luarocks_req =
-            PackageReq::new("luarocks".into(), Some(LUAROCKS_VERSION.into())).unwrap();
+            unsafe { PackageReq::new_unchecked("luarocks".into(), Some(LUAROCKS_VERSION.into())) };
 
         if !self.tree.match_rocks(&luarocks_req)?.is_found() {
-            let rockspec = RemoteLuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap();
+            let rockspec = unsafe { RemoteLuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap_unchecked() };
             let pkg = Build::new()
                 .rockspec(&rockspec)
                 .lua(lua)

--- a/lux-lib/src/manifest/mod.rs
+++ b/lux-lib/src/manifest/mod.rs
@@ -187,7 +187,9 @@ async fn mk_manifest_cache(url: &Url, config: &Config) -> io::Result<PathBuf> {
             .trim_end_matches(".zip"),
     );
     // Ensure all intermediate directories for the cache file are created (e.g. `~/.cache/lux/manifest`)
-    fs::create_dir_all(cache.parent().unwrap()).await?;
+    if let Some(cache_parent_dir) = cache.parent() {
+        fs::create_dir_all(cache_parent_dir).await?;
+    }
     Ok(cache)
 }
 

--- a/lux-lib/src/operations/pin.rs
+++ b/lux-lib/src/operations/pin.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum PinError {
-    #[error("package with ID {0} not found in lockfile")]
+    #[error("package with ID {0} not found in the lockfile")]
     PackageNotFound(LocalPackageId),
     #[error("rock {rock} is already {}pinned!", if *.pin_state == PinnedState::Unpinned { "un" } else { "" })]
     PinStateUnchanged {

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -28,6 +28,8 @@ pub enum ResolveDependenciesError {
     SearchAndDownload(#[from] SearchAndDownloadError),
     #[error("cyclic dependency detected:\n{0}")]
     CyclicDependency(DependencyCycle),
+    #[error("error processing resolved dependency:\n{0}")]
+    ChannelSend(String),
 }
 
 #[derive(Debug)]
@@ -277,7 +279,9 @@ where
                             entry_type,
                         };
 
-                        dependencies_tx.send(install_spec).unwrap();
+                        dependencies_tx.send(install_spec).map_err(|err| {
+                            ResolveDependenciesError::ChannelSend(err.to_string())
+                        })?;
 
                         Ok::<_, ResolveDependenciesError>(local_spec.id())
                     })

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -91,8 +91,9 @@ where
                     )
                 })
             {
-                let luarocks =
-                    PackageReq::new("luarocks".into(), Some(LUAROCKS_VERSION.into())).unwrap();
+                let luarocks = unsafe {
+                    PackageReq::new_unchecked("luarocks".into(), Some(LUAROCKS_VERSION.into()))
+                };
                 self = self.add_package(luarocks);
             }
         }

--- a/lux-lib/src/operations/uninstall.rs
+++ b/lux-lib/src/operations/uninstall.rs
@@ -127,18 +127,16 @@ async fn remove_package(
 
     // Delete the corresponding binaries attached to the current package (located under `{LUX_TREE}/bin/`)
     for relative_binary_path in package.spec.binaries() {
-        let binary_file_name = relative_binary_path
-            .file_name()
-            .expect("malformed lockfile");
+        if let Some(binary_file_name) = relative_binary_path.file_name() {
+            let binary_path = tree.bin().join(binary_file_name);
+            if binary_path.is_file() {
+                tokio::fs::remove_file(binary_path).await?;
+            }
 
-        let binary_path = tree.bin().join(binary_file_name);
-        if binary_path.is_file() {
-            tokio::fs::remove_file(binary_path).await?;
-        }
-
-        let unwrapped_binary_path = tree.unwrapped_bin().join(binary_file_name);
-        if unwrapped_binary_path.is_file() {
-            tokio::fs::remove_file(unwrapped_binary_path).await?;
+            let unwrapped_binary_path = tree.unwrapped_bin().join(binary_file_name);
+            if unwrapped_binary_path.is_file() {
+                tokio::fs::remove_file(unwrapped_binary_path).await?;
+            }
         }
     }
 

--- a/lux-lib/src/package/mod.rs
+++ b/lux-lib/src/package/mod.rs
@@ -234,6 +234,15 @@ impl PackageReq {
             version_req,
         })
     }
+
+    /// # Safety
+    ///
+    /// Call this only if you are absolutely sure that a `PackageReq` can be parsed from the arguments.
+    /// Calling this with invalid arguments is undefined behaviour.
+    pub unsafe fn new_unchecked(name: String, version: Option<String>) -> Self {
+        Self::new(name, version).unwrap_unchecked()
+    }
+
     pub fn parse(pkg_constraints: &str) -> Result<Self, PackageReqParseError> {
         Self::from_str(pkg_constraints)
     }

--- a/lux-lib/src/remote_package_source/mod.rs
+++ b/lux-lib/src/remote_package_source/mod.rs
@@ -43,15 +43,14 @@ impl IntoLua for RemotePackageSource {
 }
 
 impl RemotePackageSource {
-    pub(crate) unsafe fn url(self) -> Url {
+    pub(crate) fn url(self) -> Option<Url> {
         match self {
             Self::LuarocksRockspec(url)
             | Self::LuarocksSrcRock(url)
-            | Self::LuarocksBinaryRock(url) => url,
-            Self::RockspecContent(_) => panic!("tried to get URL from RockspecContent"),
-            RemotePackageSource::Local => panic!("tried to get URL from Local"),
+            | Self::LuarocksBinaryRock(url) => Some(url),
+            Self::RockspecContent(_) | Self::Local => None,
             #[cfg(test)]
-            Self::Test => unimplemented!(),
+            Self::Test => None,
         }
     }
 }

--- a/lux-lib/src/rockspec/mod.rs
+++ b/lux-lib/src/rockspec/mod.rs
@@ -124,7 +124,8 @@ impl<T: Rockspec> LuaVersionCompatibility for T {
             ("5.2.0", LuaVersion::Lua52),
             ("5.1.0", LuaVersion::Lua51),
         ] {
-            if self.lua().matches(&possibility.parse().unwrap()) {
+            let possibility = unsafe { possibility.parse().unwrap_unchecked() };
+            if self.lua().matches(&possibility) {
                 return Some(version);
             }
         }

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -306,8 +306,7 @@ mod helpers {
         endpoint: &str,
     ) -> Result<Url, url::ParseError> {
         server_url
-            .join("api/1/")
-            .expect("error constructing 'api/1/' path")
+            .join("api/1/")?
             .join(&format!("{}/", api_key.get()))?
             .join(endpoint)
     }

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -76,7 +76,7 @@ fn do_search(which: Which<'_>) -> Result<PathBuf, WhichError> {
                 lockfile
                     .find_rocks(req)
                     .into_iter()
-                    .map(|id| lockfile.get(&id).unwrap())
+                    .filter_map(|id| lockfile.get(&id))
                     .cloned()
                     .collect_vec()
             })

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -117,6 +117,7 @@ async fn command_build() {
     test_build_rockspec("resources/test/luaposix-35.1-1.rockspec".into()).await
 }
 
+#[cfg(test)]
 async fn test_build_rockspec(rockspec_path: PathBuf) {
     let dir = TempDir::new().unwrap();
 

--- a/lux-lib/tests/install.rs
+++ b/lux-lib/tests/install.rs
@@ -55,6 +55,7 @@ async fn no_build_artifacts_in_cwd() {
     assert_eq!(build_artifacts, vec![] as Vec<PathBuf>)
 }
 
+#[cfg(test)]
 async fn test_install(install_spec: PackageInstallSpec) {
     let dir = TempDir::new().unwrap();
     let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));

--- a/lux-lib/tests/test.rs
+++ b/lux-lib/tests/test.rs
@@ -101,6 +101,7 @@ async fn run_busted_nlua_test_no_lock() {
 // On macOS, it appears that Neovim segfaults when `require`ing `lfs` (luafilesystem).
 // Investigation is needed on Windows.
 #[cfg(target_os = "linux")]
+#[cfg(test)]
 async fn run_busted_nlua_test_impl(no_lock: bool) {
     let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("resources/test/sample-projects/busted-nlua/");

--- a/lux-lua/Cargo.toml
+++ b/lux-lua/Cargo.toml
@@ -30,3 +30,8 @@ vendored = ["lux-lib/vendored-openssl", "lux-lib/vendored-libgit2"]
 # Run tests without module mode so we can link against Lua and run the tests.
 test = ["mlua/vendored", "lux-lib/lua51"]
 ssh-tests = ["lux-lib/ssh-tests"]
+
+[lints.clippy]
+panic = "warn"
+unwrap_used = "warn"
+expect_used = "warn"


### PR DESCRIPTION
This is breaking for lux-lib because it changes some of the `Error` types.

Motivation: Lux is heavily parallelized. It assumes that all install threads will either succeed or evaluate to an `Err`.
A thread panicking can lead to undefined behaviour that is difficult to troubleshoot.