### PR TITLE
fix(lint)!: don't install luacheck to project tree

### DIFF
--- a/lux-cli/src/lint.rs
+++ b/lux-cli/src/lint.rs
@@ -1,13 +1,7 @@
 use clap::Args;
 use eyre::Result;
 use itertools::Itertools;
-use lux_lib::{
-    config::Config,
-    operations::{Exec, Install, PackageInstallSpec},
-    progress::MultiProgress,
-    project::Project,
-    tree,
-};
+use lux_lib::{config::Config, operations::Exec, project::Project};
 use path_slash::PathBufExt;
 
 use crate::project::top_level_ignored_files;
@@ -25,33 +19,29 @@ pub struct Lint {
 }
 
 pub async fn lint(lint_args: Lint, config: Config) -> Result<()> {
-    let project = Project::current_or_err()?;
-
-    let luacheck =
-        PackageInstallSpec::new("luacheck".parse()?, tree::EntryType::Entrypoint).build();
-
-    Install::new(&config)
-        .package(luacheck)
-        .project(&project)?
-        .progress(MultiProgress::new_arc(&config))
-        .install()
-        .await?;
+    let project = Project::current()?;
+    let root_dir = match &project {
+        Some(project) => project.root().to_slash_lossy().to_string(),
+        None => std::env::current_dir()?.to_slash_lossy().to_string(),
+    };
 
     let check_args: Vec<String> = match lint_args.args {
         Some(args) => args,
         None if lint_args.no_ignore => Vec::new(),
         None => {
-            let ignored_files = top_level_ignored_files(&project)
-                .into_iter()
-                .map(|file| file.to_slash_lossy().to_string());
+            let ignored_files = project.iter().flat_map(|project| {
+                top_level_ignored_files(project)
+                    .into_iter()
+                    .map(|file| file.to_slash_lossy().to_string())
+            });
             std::iter::once("--exclude-files".into())
                 .chain(ignored_files)
                 .collect_vec()
         }
     };
 
-    Exec::new("luacheck", Some(&project), &config)
-        .arg(project.root().to_slash_lossy())
+    Exec::new("luacheck", None, &config)
+        .arg(root_dir)
         .args(check_args)
         .disable_loader(true)
         .exec()


### PR DESCRIPTION
Fixes #1286.
This also allows `lx lint` to work outside of Lux projects.