### PR TITLE
feat(fmt)!: format `spec` directory

### DIFF
--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -38,6 +38,7 @@ pub fn format(args: Fmt) -> Result<()> {
         .into_iter()
         .chain(WalkDir::new(project.root().join("lua")))
         .chain(WalkDir::new(project.root().join("lib")))
+        .chain(WalkDir::new(project.root().join("spec")))
         .filter_map(Result::ok)
         .filter(|file| {
             args.workspace_or_file


### PR DESCRIPTION
Hey, it would be nice if the `lx fmt` command also formatted the spec folder.

I've tested this manually and it seems fine, I've tested it formatting the folder and the folder not existing at all