### PR TITLE
docs(readme): update luacheck url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * Automatic EmmyLua/LuaCATS based type checking via `lx check`
   - Powered by [`emmylua-analyzer-rust`](https://github.com/EmmyLuaLs/emmylua-analyzer-rust)
 * Automatic code linting via `lx lint`
-  - Powered by [`luacheck`](https://github.com/mpeterv/luacheck)
+  - Powered by [`luacheck`](https://github.com/lunarmodules/luacheck)
 * Powerful lockfile support
   - Makes for fully reproducible developer environments.
   - Makes Lux easy to integrate with Nix!


### PR DESCRIPTION
When I've checked the versions of `lx lint`:

```
$ lx --lua-version jit lint -- --version
Luacheck: 1.2.0
Lua: LuaJIT 2.1.1767980792
Argparse: 0.7.1
LuaFileSystem: 1.9.0
LuaLanes: Not found
$ lx --lua-version 5.4 lint -- --version
Luacheck: 1.2.0
Lua: PUC-Rio Lua 5.4
Argparse: 0.7.1
LuaFileSystem: 1.9.0
LuaLanes: Not found
```

1.2.0 does not exist on [mpeterv/luacheck](https://github.com/mpeterv/luacheck) which is a repository not updated since 2018.

[`luacheck` on LuaRocks](https://luarocks.org/modules/lunarmodules/luacheck) is powered by [lunarmodules/luacheck](https://github.com/lunarmodules/luacheck). I guess it is the installed `luacheck`. So updating it.
