### PR TITLE
feat: add `lx sync` command

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -7,7 +7,7 @@ use lux_cli::{
     debug::Debug,
     doc, download, exec, fetch, format, generate_rockspec, info, install, install_lua,
     install_rockspec, lint, list, outdated, pack, path, pin, project, purge, remove, run, run_lua,
-    search, shell, test, uninstall, unpack, update,
+    search, shell, sync, test, uninstall, unpack, update,
     upload::{self},
     vendor, which, Cli, Commands,
 };
@@ -108,6 +108,7 @@ async fn main() -> Result<()> {
         Commands::Run(run_args) => run::run(run_args, config).await?,
         Commands::GenerateRockspec(data) => generate_rockspec::generate_rockspec(data)?,
         Commands::Shell(data) => shell::shell(data, config).await?,
+        Commands::Sync(sync_args) => sync::sync(sync_args, config).await?,
     }
     Ok(())
 }

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -27,6 +27,7 @@ use run::Run;
 use run_lua::RunLua;
 use search::Search;
 use shell::Shell;
+use sync::SyncProject;
 use test::Test;
 use uninstall::Uninstall;
 use update::Update;
@@ -64,6 +65,7 @@ pub mod run;
 pub mod run_lua;
 pub mod search;
 pub mod shell;
+pub mod sync;
 pub mod test;
 pub mod uninstall;
 pub mod unpack;
@@ -326,6 +328,9 @@ pub enum Commands {
     Which(Which),
     /// Spawns an interactive shell with PATH, LUA_PATH, LUA_CPATH and LUA_INIT set.
     Shell(Shell),
+    /// Synchronize the project tree with the current lux.toml,{n}
+    /// ensuring all packages are installed correctly.
+    Sync(SyncProject),
 }
 
 /// Parse a key=value pair.

--- a/lux-cli/src/sync.rs
+++ b/lux-cli/src/sync.rs
@@ -1,0 +1,65 @@
+use clap::Args;
+use eyre::{OptionExt, Result};
+use lux_lib::{
+    config::Config, lockfile::LocalPackage, operations::Sync, progress::MultiProgress,
+    project::Project,
+};
+
+#[derive(Args)]
+pub struct SyncProject {
+    /// Skip the integrity checks for installed rocks when syncing the project lockfile.
+    #[arg(long)]
+    no_integrity_check: bool,
+}
+
+/// Sync the current project's installed packages with its lux.toml.
+pub async fn sync(args: SyncProject, config: Config) -> Result<()> {
+    let project = Project::current()?.ok_or_eyre("No project found")?;
+    let progress = MultiProgress::new_arc(&config);
+
+    let dep_report = Sync::new(&project, &config)
+        .progress(progress.clone())
+        .validate_integrity(!args.no_integrity_check)
+        .sync_dependencies()
+        .await?;
+
+    let build_report = Sync::new(&project, &config)
+        .progress(progress.clone())
+        .validate_integrity(false)
+        .sync_build_dependencies()
+        .await?;
+
+    let test_report = Sync::new(&project, &config)
+        .progress(progress.clone())
+        .validate_integrity(false)
+        .sync_test_dependencies()
+        .await?;
+
+    let added: Vec<&LocalPackage> = dep_report
+        .added()
+        .iter()
+        .chain(build_report.added().iter())
+        .chain(test_report.added().iter())
+        .collect();
+
+    let removed: Vec<&LocalPackage> = dep_report
+        .removed()
+        .iter()
+        .chain(build_report.removed().iter())
+        .chain(test_report.removed().iter())
+        .collect();
+
+    if added.is_empty() && removed.is_empty() {
+        println!("Already in sync.");
+        return Ok(());
+    }
+
+    for pkg in added {
+        println!("+ {} {}", pkg.name(), pkg.version());
+    }
+    for pkg in removed {
+        println!("- {} {}", pkg.name(), pkg.version());
+    }
+
+    Ok(())
+}

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -107,6 +107,15 @@ pub struct SyncReport {
     pub(crate) removed: Vec<LocalPackage>,
 }
 
+impl SyncReport {
+    pub fn added(&self) -> &[LocalPackage] {
+        &self.added
+    }
+    pub fn removed(&self) -> &[LocalPackage] {
+        &self.removed
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum SyncError {
     #[error(transparent)]


### PR DESCRIPTION
Sometimes the local package installs can get out of sync with the `lux.toml`. Having a `sync` command to get it all back on track is a nice convenience feature.

Note: there seems to be an issue where if you remove `.lux/`, `lx sync` will still claim that everything's alright. our `Sync` builder should probably also verify that the files exist on disk and reinstall if not.