### PR TITLE
feat!: remove From<bool> for BuildBehaviour

### DIFF
--- a/lux-cli/src/utils/install.rs
+++ b/lux-cli/src/utils/install.rs
@@ -34,7 +34,11 @@ pub fn apply_build_behaviour(
                     .iter()
                     .all(|pkg_id| !lockfile.is_entrypoint(pkg_id));
             let build_behaviour: Option<BuildBehaviour> = if force || existing_packages.is_empty() {
-                Some(BuildBehaviour::from(force))
+                Some(if force {
+                    BuildBehaviour::Force
+                } else {
+                    BuildBehaviour::NoForce
+                })
             } else if Confirm::new(&format!("Package {req} already exists. Overwrite?"))
                 .with_default(false)
                 .prompt()

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -37,7 +37,6 @@ use make::MakeError;
 
 use patch::{Patch, PatchError};
 use rust_mlua::RustError;
-use serde::{Deserialize, Deserializer};
 use source::SourceBuildError;
 use ssri::Integrity;
 use thiserror::Error;
@@ -167,25 +166,6 @@ pub enum BuildBehaviour {
     NoForce,
     /// Force a rebuild if the package is already installed
     Force,
-}
-
-impl<'de> Deserialize<'de> for BuildBehaviour {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Self::from(bool::deserialize(deserializer)?))
-    }
-}
-
-impl From<bool> for BuildBehaviour {
-    fn from(value: bool) -> Self {
-        if value {
-            Self::Force
-        } else {
-            Self::NoForce
-        }
-    }
 }
 
 async fn run_build<R: Rockspec + HasIntegrity>(


### PR DESCRIPTION
Remove the `From<bool>` impl for `BuildBehaviour` as suggested in #1419 — the conversion has no clear semantic meaning (`true` → `Force` isn't obvious without reading the impl).

The single call site in `install.rs` now uses an explicit `if`/`else`, and the `Deserialize` impl inlines the same logic directly.

Closes #1419