### PR TITLE
fix(ci): properly parse release plz changelogs

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 body = """
 
-## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} `{{ package }}` - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}


### PR DESCRIPTION
This seems to have been the problem: the `parse-changelog` crate wasn't able to properly parse the changelog file because of our custom format. It expects a version as the first thing in each heading so this should now make our changelogs work again :)